### PR TITLE
VFS Changes

### DIFF
--- a/src/drivers/generic/initrd/main.c
+++ b/src/drivers/generic/initrd/main.c
@@ -56,10 +56,10 @@ void driver_cleanup_callback()
 OBOS_WEAK obos_status query_path(dev_desc desc, const char** path);
 OBOS_WEAK obos_status path_search(dev_desc* found, void*, const char* what);
 OBOS_WEAK obos_status get_linked_desc(dev_desc desc, dev_desc* found);
-OBOS_PAGEABLE_FUNCTION obos_status move_desc_to(dev_desc desc, const char* where)
+OBOS_PAGEABLE_FUNCTION obos_status move_desc_to(dev_desc desc, dev_desc new_parent, const char* name)
 {
     OBOS_UNUSED(desc);
-    OBOS_UNUSED(where);
+    OBOS_UNUSED(new_parent && name);
     return OBOS_STATUS_READ_ONLY;
 }
 OBOS_PAGEABLE_FUNCTION obos_status mk_file(dev_desc* newDesc, dev_desc parent, void* vn, const char* name, file_type type) {

--- a/src/drivers/generic/libps2/keyboard.c
+++ b/src/drivers/generic/libps2/keyboard.c
@@ -168,7 +168,7 @@ obos_status get_readable_count(void* handle, size_t* nReadable)
         return OBOS_STATUS_INVALID_ARGUMENT;
     ps2_port* port = hnd->port;
     ps2k_data* data = port->pudata;
-    *nReadable = (hnd->in_ptr - data->input.out_ptr);
+    *nReadable = (data->input.out_ptr - hnd->in_ptr);
     return OBOS_STATUS_SUCCESS;
 }
 

--- a/src/drivers/generic/libps2/keyboard.c
+++ b/src/drivers/generic/libps2/keyboard.c
@@ -15,6 +15,8 @@
 #include <mm/page.h>
 #include <mm/pmm.h>
 
+#include <irq/dpc.h>
+
 #include <locks/event.h>
 #include <locks/wait.h>
 
@@ -26,6 +28,13 @@
 #include "scancode_tables.h"
 #include "controller.h"
 #include "detect.h"
+
+static void signal_ring_buffer_dpc(dpc* d, void* userdata)
+{
+    OBOS_UNUSED(d);
+    ps2k_ringbuffer* buff = userdata;
+    Core_EventSet(&buff->e, true);
+}
 
 static void keyboard_ready(ps2_port* port, uint8_t scancode)
 {
@@ -125,7 +134,10 @@ static void keyboard_ready(ps2_port* port, uint8_t scancode)
     KEYCODE_ADD_MODIFIER(code, data->super_key ? SUPER_KEY : 0);
 
     // OBOS_Debug("Got key %s (0x%02x), modifiers 0x%02x\n", OBOS_ScancodeToString[SCANCODE_FROM_KEYCODE(code)], SCANCODE_FROM_KEYCODE(code), MODIFIERS_FROM_KEYCODE(code));
-    PS2_RingbufferAppend(&data->input, code, true);
+    PS2_RingbufferAppend(&data->input, code, false);
+    
+    data->dpc.userdata = &data->input;
+    CoreH_InitializeDPC(&data->dpc, signal_ring_buffer_dpc, 0);
 }
 
 ps2k_data keyboard_data_buf[2];

--- a/src/drivers/generic/libps2/keyboard.h
+++ b/src/drivers/generic/libps2/keyboard.h
@@ -13,6 +13,8 @@
 
 #include <locks/event.h>
 
+#include <irq/dpc.h>
+
 #include "controller.h"
 
 #define PS2_ACK 0xfa
@@ -52,6 +54,7 @@ typedef struct ps2k_data {
     struct ps2k_ringbuffer input;
     ps2_port* port;
     uint32_t ps2k_magic;
+    dpc dpc;
     uint8_t set;
     bool initialized : 1;
     bool processing_extended : 1;

--- a/src/drivers/generic/slowfat/create.c
+++ b/src/drivers/generic/slowfat/create.c
@@ -118,7 +118,6 @@ obos_status mk_file(dev_desc* newDesc, dev_desc parent_desc, void* vn_, const ch
         dot_entries[1].first_cluster_low = parent->data.first_cluster_low;
         dot_entries[1].first_cluster_high = parent->data.first_cluster_high;
         dot_entries[1].filename_83[1] = '.';
-        printf("%d\n", ClusterToSector(cache, cluster));
         page* pg = nullptr;
         void* buff = VfsH_PageCacheGetEntry(cache->volume->vn, ClusterToSector(cache, cluster)*cache->blkSize, &pg);
         memcpy(buff, dot_entries, sizeof(dot_entries));

--- a/src/drivers/generic/slowfat/create.c
+++ b/src/drivers/generic/slowfat/create.c
@@ -149,6 +149,8 @@ static void gen_short_name_impl(const char* long_name, char* name)
         for (uint8_t i = 0; i < 3 && i < strlen(long_name+off); i++)
             name[i+8] = toupper(long_name[off+i]);
     }
+    else
+        memset(name+short_i, ' ', 11-short_i);    
 }
 static void gen_short_name(const char* long_name, char* name, fat_dirent_cache* parent, fat_dirent_cache* dirent)
 {
@@ -433,9 +435,9 @@ static void ref_dirent(fat_dirent_cache* cache_entry)
         entry_cluster = cluster;
     }
     Vfs_FdSeek(cache->volume, fileoff, SEEK_SET);
-    void* buf = VfsH_PageCacheGetEntry(cache->vn, fileoff, false);
+    void* buf = VfsH_PageCacheGetEntry(cache->vn, fileoff, true);
     fileoff = Vfs_FdTellOff(cache->volume);
-    fat_dirent* curr = buf+(fileoff%blkSize);
+    fat_dirent* curr = buf;
     for (size_t i = 0; i < nEntries; i++)
     {
         fat_dirent* curr_dirent = &cache_entry->data;
@@ -479,7 +481,7 @@ static void ref_dirent(fat_dirent_cache* cache_entry)
                 Vfs_FdSeek(cache->volume, ClusterToSector(cache, next)*cache->blkSize, SEEK_SET);
                 fileoff = Vfs_FdTellOff(cache->volume);
                 Vfs_FdRead(cache->volume, buf, blkSize, nullptr);
-                buf = VfsH_PageCacheGetEntry(cache->vn, fileoff/cache->blkSize*cache->blkSize, true);
+                buf = VfsH_PageCacheGetEntry(cache->vn, fileoff, true);
                 curr = buf;
             }
         }

--- a/src/drivers/generic/slowfat/main.c
+++ b/src/drivers/generic/slowfat/main.c
@@ -41,7 +41,7 @@ void driver_cleanup_callback()
 OBOS_WEAK obos_status query_path(dev_desc desc, const char** path);
 OBOS_WEAK obos_status path_search(dev_desc* found, void*, const char* what);
 OBOS_WEAK obos_status get_linked_desc(dev_desc desc, dev_desc* found);
-OBOS_WEAK obos_status move_desc_to(dev_desc desc, const char* where);
+OBOS_WEAK obos_status move_desc_to(dev_desc desc, dev_desc new_parent, const char* name);
 OBOS_WEAK obos_status mk_file(dev_desc* newDesc, dev_desc parent, void* vn, const char* name, file_type type);
 OBOS_WEAK obos_status remove_file(dev_desc desc);
 OBOS_WEAK obos_status trunc_file(dev_desc desc, size_t newsize);

--- a/src/drivers/generic/slowfat/probe.c
+++ b/src/drivers/generic/slowfat/probe.c
@@ -155,7 +155,7 @@ static iterate_decision dir_iterate_impl(uint32_t current_cluster, obos_status s
         return ITERATE_DECISION_STOP;
     fat_cache* cache = (void*)((uintptr_t*)udata)[0];
     fat_dirent_cache* parent = (void*)((uintptr_t*)udata)[1];
-    const void* buff = VfsH_PageCacheGetEntry(cache->volume->vn, ClusterToSector(cache, current_cluster)*cache->blkSize, false);
+    const void* buff = VfsH_PageCacheGetEntry(cache->volume->vn, ClusterToSector(cache, current_cluster)*cache->blkSize, nullptr);
     const fat_dirent* curr = buff;
     string current_filename = {};
     lfn_dirent **lfn_entries = nullptr;
@@ -264,7 +264,7 @@ bool probe(void* vn_)
         Vfs_FdSeek(cache->volume, cache->root_sector*cache->blkSize, SEEK_SET);
         for (size_t i = cache->root_sector; i < (cache->root_sector+cache->RootDirSectors); i++)
         {
-            const void* buff = VfsH_PageCacheGetEntry(volume->vn, i*cache->blkSize, false);
+            const void* buff = VfsH_PageCacheGetEntry(volume->vn, i*cache->blkSize, nullptr);
             const fat_dirent* curr = buff;
             for (size_t j = 0; j < (cache->blkSize/sizeof(lfn_dirent)); j++, curr++)
             {

--- a/src/drivers/generic/slowfat/structs.h
+++ b/src/drivers/generic/slowfat/structs.h
@@ -80,18 +80,20 @@ enum {
     ARCHIVE=0x20,
     LFN=READ_ONLY|HIDDEN|SYSTEM|VOLUME_ID,
 };
-typedef struct fat_date
-{
-    uint8_t      day : 5;
-    uint8_t    month : 4;
-    uint8_t year1980 : 7;
-} OBOS_PACK fat_date;
-typedef struct fat_time
-{
-    uint8_t seconds : 5; // multiply by two
-    uint8_t minutes : 6;
-    uint8_t hour : 5;
-} OBOS_PACK fat_time;
+// typedef struct fat_date
+// {
+//     uint8_t      day : 5;
+//     uint8_t    month : 4;
+//     uint8_t year1980 : 7;
+// } OBOS_PACK fat_date;
+// typedef struct fat_time
+// {
+//     uint8_t seconds : 5; // multiply by two
+//     uint8_t minutes : 6;
+//     uint8_t hour : 5;
+// } OBOS_PACK fat_time;
+typedef uint16_t fat_date;
+typedef uint16_t fat_time;
 typedef struct fat_dirent
 {
     char filename_83[11];

--- a/src/oboskrnl/CMakeLists.txt
+++ b/src/oboskrnl/CMakeLists.txt
@@ -19,7 +19,7 @@ list (APPEND oboskrnl_sources
 	"mm/fork.c" "power/suspend.c" "power/device.c" "power/init.c"
 	"driver_interface/pci.c" "utils/shared_ptr.c" "locks/sys_futex.c" "vfs/fd_sys.c"
 	"elf/load.c" "driver_interface/drv_sys.c" "sig_sys.c" "execve.c"
-	"init_proc.c"
+	"init_proc.c" "vfs/create.c"
 )
 
 add_executable(oboskrnl)

--- a/src/oboskrnl/arch/x86_64/entry.c
+++ b/src/oboskrnl/arch/x86_64/entry.c
@@ -874,10 +874,6 @@ void Arch_KernelMainBootstrap()
     OBOS_Debug("%s: Finalizing VFS initialization...\n", __func__);
     Vfs_FinalizeInitialization();
 
-    fd nic = {};
-    Vfs_FdOpen(&nic, "/dev/r8169-eth0", FD_OFLAGS_READ|FD_OFLAGS_WRITE);
-    // OBOS_Suspend();
-
     fd com1 = {};
     Vfs_FdOpen(&com1, "/dev/COM1", FD_OFLAGS_READ);
 

--- a/src/oboskrnl/arch/x86_64/except.c
+++ b/src/oboskrnl/arch/x86_64/except.c
@@ -100,7 +100,7 @@ __attribute__((no_instrument_function)) OBOS_NO_UBSAN OBOS_NO_KASAN void Arch_Pa
     down:
     asm("cli");
     OBOS_Panic(OBOS_PANIC_EXCEPTION, 
-        "Page fault at 0x%p in %s-mode while to %s page at 0x%p, which is %s. Error code: %d\n"
+        "Page fault at 0x%p in %s-mode while trying to %s page at 0x%p, which is %s. Error code: %d\n"
         "Register dump:\n"
         "\tRDI: 0x%016lx, RSI: 0x%016lx, RBP: 0x%016lx\n"
         "\tRSP: 0x%016lx, RBX: 0x%016lx, RDX: 0x%016lx\n"

--- a/src/oboskrnl/arch/x86_64/idt.c
+++ b/src/oboskrnl/arch/x86_64/idt.c
@@ -21,22 +21,11 @@
 #include <arch/x86_64/idt.h>
 #include <arch/x86_64/lapic.h>
 #include <arch/x86_64/irq_vector.h>
-
 #include <arch/x86_64/asm_helpers.h>
 
 extern char Arch_b_isr_handler;
 extern char Arch_e_isr_handler;
 
-struct idtEntry
-{
-	uint16_t offset1;
-	uint16_t selector;
-	uint8_t ist;
-	uint8_t typeAttributes;
-	uint16_t offset2;
-	uint32_t offset3;
-	uint32_t resv1;
-};
 struct idtEntry g_idtEntries[256];
 struct idtPointer
 {

--- a/src/oboskrnl/arch/x86_64/idt.h
+++ b/src/oboskrnl/arch/x86_64/idt.h
@@ -10,6 +10,17 @@
 
 #include <arch/x86_64/interrupt_frame.h>
 
+struct idtEntry
+{
+	uint16_t offset1;
+	uint16_t selector;
+	uint8_t ist;
+	uint8_t typeAttributes;
+	uint16_t offset2;
+	uint32_t offset3;
+	uint32_t resv1;
+};
+
 void Arch_InitializeIDT(bool isBSP);
 void Arch_RawRegisterInterrupt(uint8_t vec, uintptr_t f);
 void Arch_PutInterruptOnIST(uint8_t vec, uint8_t ist);

--- a/src/oboskrnl/arch/x86_64/map.c
+++ b/src/oboskrnl/arch/x86_64/map.c
@@ -17,10 +17,6 @@
 
 #include <mm/pmm.h>
 
-#include <arch/x86_64/asm_helpers.h>
-
-#include <arch/x86_64/boot_info.h>
-
 #include <elf/elf.h>
 
 #include <scheduler/cpu_local.h>
@@ -28,6 +24,8 @@
 #include <locks/spinlock.h>
 
 #include <arch/x86_64/idt.h>
+#include <arch/x86_64/asm_helpers.h>
+#include <arch/x86_64/boot_info.h>
 #include <arch/x86_64/interrupt_frame.h>
 #include <arch/x86_64/lapic.h>
 
@@ -540,7 +538,7 @@ page_table MmS_AllocatePageTable()
 		// Map cpu local structs.
 		map_range(cached_root, (uintptr_t)Core_CpuInfo, (uintptr_t)(Core_CpuInfo + Core_CpuCount), 1|BIT_TYPE(63, UL)|2);
 		// Map IDT
-		extern char g_idtEntries;
+		extern struct idtEntry g_idtEntries[256];
 		map_range(cached_root, (uintptr_t)&g_idtEntries, ((uintptr_t)&g_idtEntries) + 0x1000, 1|BIT_TYPE(63, UL)|2);
 		extern uintptr_t Arch_IRQHandlers[256];
 		map_range(cached_root, (uintptr_t)&Arch_IRQHandlers, ((uintptr_t)&Arch_IRQHandlers) + sizeof(Arch_IRQHandlers), 1|BIT_TYPE(63, UL)|2);

--- a/src/oboskrnl/arch/x86_64/map.c
+++ b/src/oboskrnl/arch/x86_64/map.c
@@ -469,11 +469,11 @@ obos_status MmS_QueryPageInfo(page_table pt, uintptr_t addr, page_info* ppage, u
 	if (ppage)
 	{
 		ppage->virt = addr;
-		ppage->phys = page.prot.huge_page ? (entry & ~0x1fffff) : Arch_MaskPhysicalAddressFromEntry(entry);
+		ppage->phys = page.prot.huge_page ? (entry & 0xFFFFFFFE00000) : Arch_MaskPhysicalAddressFromEntry(entry);
 		memcpy(&ppage->prot, &page.prot, sizeof(page.prot));
 	}
 	if (phys)
-		*phys = Arch_MaskPhysicalAddressFromEntry(entry);
+		*phys = page.prot.huge_page ? (entry & 0xFFFFFFFE00000) : Arch_MaskPhysicalAddressFromEntry(entry);
 	return OBOS_STATUS_SUCCESS;	
 }
 obos_status MmS_SetPageMapping(page_table pt, const page_info* page, uintptr_t phys, bool free_pte)

--- a/src/oboskrnl/arch/x86_64/map.c
+++ b/src/oboskrnl/arch/x86_64/map.c
@@ -469,7 +469,7 @@ obos_status MmS_QueryPageInfo(page_table pt, uintptr_t addr, page_info* ppage, u
 	if (ppage)
 	{
 		ppage->virt = addr;
-		ppage->phys = Arch_MaskPhysicalAddressFromEntry(entry);
+		ppage->phys = page.prot.huge_page ? (entry & ~0x1fffff) : Arch_MaskPhysicalAddressFromEntry(entry);
 		memcpy(&ppage->prot, &page.prot, sizeof(page.prot));
 	}
 	if (phys)

--- a/src/oboskrnl/arch/x86_64/syscall.c
+++ b/src/oboskrnl/arch/x86_64/syscall.c
@@ -181,6 +181,11 @@ const char* syscall_to_string[] = {
     "Sys_SleepMS",
     "Sys_Mount",
     "Sys_Unmount",
+    "Sys_FdCreat",
+    "Sys_FdOpenEx",
+    "Sys_FdOpenAtEx",
+    "Sys_Mkdir",
+    "Sys_MkdirAt",
 };
 
 void Arch_LogSyscall(uintptr_t rdi, uintptr_t rsi, uintptr_t rdx, uintptr_t r8, uintptr_t r9, uint32_t eax)

--- a/src/oboskrnl/arch/x86_64/syscall.c
+++ b/src/oboskrnl/arch/x86_64/syscall.c
@@ -186,6 +186,9 @@ const char* syscall_to_string[] = {
     "Sys_FdOpenAtEx",
     "Sys_Mkdir",
     "Sys_MkdirAt",
+    "Sys_Chdir",
+    "Sys_ChdirEnt",
+    "Sys_GetCWD",
 };
 
 void Arch_LogSyscall(uintptr_t rdi, uintptr_t rsi, uintptr_t rdx, uintptr_t r8, uintptr_t r9, uint32_t eax)

--- a/src/oboskrnl/arch/x86_64/timer.c
+++ b/src/oboskrnl/arch/x86_64/timer.c
@@ -159,7 +159,7 @@ OBOS_PAGEABLE_FUNCTION obos_status CoreS_InitializeTimer(irq_handler handler)
         OBOS_Panic(OBOS_PANIC_DRIVER_FAILURE, "Could not find empty I/O APIC IRQ for the HPET. irqRouting=0x%08x\n", irqRouting);
     OBOS_ASSERT(gsi <= 32);
     timer->timerConfigAndCapabilities |= (1<6)|(1<<3)|((uint8_t)gsi<<9); // Edge-triggered IRQs, set GSI, Periodic timer
-    CoreS_TimerFrequency = 500;
+    CoreS_TimerFrequency = 2000;
     OBOS_Debug("HPET frequency: %ld, configured HPET frequency: %ld\n", Arch_HPETFrequency, CoreS_TimerFrequency);
     const uint64_t value = Arch_HPETFrequency/CoreS_TimerFrequency;
     timer->timerComparatorValue = Arch_HPETAddress->mainCounterValue + value;

--- a/src/oboskrnl/driver_interface/header.h
+++ b/src/oboskrnl/driver_interface/header.h
@@ -161,7 +161,10 @@ typedef struct driver_ftable
 
     // vn is optional if parent is not UINTPTR_MAX (root directory).
     obos_status(*mk_file)(dev_desc* newDesc, dev_desc parent, void* vn, const char* name, file_type type);
-    obos_status(*move_desc_to)(dev_desc desc, const char* where);
+    // If !new_parent && name, then we need to rename the file.
+    // If new_parent && !name, then we need to move the file to the new parent, and keep the filename.
+    // If new_parent && name, then we need to move the file to new parent and rename the file.
+    obos_status(*move_desc_to)(dev_desc desc, dev_desc new_parent_desc, const char* name);
     obos_status(*remove_file)(dev_desc desc);
     obos_status(*trunc_file)(dev_desc desc, size_t newsize /* note, newsize must be less than the filesize */);
 

--- a/src/oboskrnl/execve.c
+++ b/src/oboskrnl/execve.c
@@ -47,9 +47,10 @@ static bool OBOS_CROSSES_PAGE_BOUNDARY(void* ptr_, size_t sz)
 // vec is terminated with a nullptr entry.
 static char** allocate_user_vector_as_kernel(context* ctx, char* const* vec, size_t* const szvec, obos_status* status)
 {
-    char** kstr = Mm_MapViewOfUserMemory(ctx, (void*)vec, nullptr, OBOS_PAGE_SIZE, OBOS_PROTECTION_READ_ONLY, true, status);
+    char** kstr = Mm_MapViewOfUserMemory(ctx, (void*)((uintptr_t)vec - ((uintptr_t)vec % OBOS_PAGE_SIZE)), nullptr, OBOS_PAGE_SIZE, OBOS_PROTECTION_READ_ONLY, true, status);
     if (!kstr)
         return nullptr;
+    kstr = (void*)(((uintptr_t)kstr) + (uintptr_t)vec % OBOS_PAGE_SIZE);
 
     char** iter = kstr;
     uintptr_t offset = (uintptr_t)kstr-(uintptr_t)iter;

--- a/src/oboskrnl/mm/context.c
+++ b/src/oboskrnl/mm/context.c
@@ -135,6 +135,9 @@ void MmH_DerefPage(page* buf)
 	{
 		if (~buf->flags & PHYS_PAGE_MMIO)
 			Mm_FreePhysicalPages(buf->phys, ((buf->flags & PHYS_PAGE_HUGE_PAGE) ? OBOS_HUGE_PAGE_SIZE : OBOS_PAGE_SIZE) / OBOS_PAGE_SIZE);
+		OBOS_ENSURE (~buf->flags & PHYS_PAGE_DIRTY);
+		OBOS_ENSURE (~buf->flags & PHYS_PAGE_STANDBY);
+
 		// printf("removed page from tree (refcount %d)\n", buf->refcount);
 		RB_REMOVE(phys_page_tree, &Mm_PhysicalPages, buf);
 		if (buf->backing_vn)

--- a/src/oboskrnl/mm/context.c
+++ b/src/oboskrnl/mm/context.c
@@ -135,8 +135,12 @@ void MmH_DerefPage(page* buf)
 	{
 		if (~buf->flags & PHYS_PAGE_MMIO)
 			Mm_FreePhysicalPages(buf->phys, ((buf->flags & PHYS_PAGE_HUGE_PAGE) ? OBOS_HUGE_PAGE_SIZE : OBOS_PAGE_SIZE) / OBOS_PAGE_SIZE);
-		OBOS_ENSURE (~buf->flags & PHYS_PAGE_DIRTY);
-		OBOS_ENSURE (~buf->flags & PHYS_PAGE_STANDBY);
+		
+		if (buf->flags & PHYS_PAGE_DIRTY)
+			LIST_REMOVE(phys_page_list, &Mm_DirtyPageList, buf);
+		else if (buf->flags & PHYS_PAGE_STANDBY)
+			LIST_REMOVE(phys_page_list, &Mm_StandbyPageList, buf);
+
 
 		// printf("removed page from tree (refcount %d)\n", buf->refcount);
 		RB_REMOVE(phys_page_tree, &Mm_PhysicalPages, buf);

--- a/src/oboskrnl/mm/handler.c
+++ b/src/oboskrnl/mm/handler.c
@@ -48,18 +48,17 @@ static void map_file_region(page_range* rng, uintptr_t addr, uint32_t ec, fault_
     if (!phys)
     {
         *type = HARD_FAULT;
-        phys = VfsH_PageCacheCreateEntry(rng->un.mapped_vn, addr-rng->virt, ec & PF_EC_RW);
+        phys = VfsH_PageCacheCreateEntry(rng->un.mapped_vn, addr-rng->virt);
     }
     else
-    {
         *type = SOFT_FAULT;
-        if (ec & PF_EC_RW)
-            Mm_MarkAsDirtyPhys(phys);
-    }
     MmH_RefPage(phys);
+    if (ec & PF_EC_RW)
+        Mm_MarkAsDirtyPhys(phys);
     info->phys = phys->phys;
     info->prot.present = true;
     info->prot.rw = rng->prot.rw && !(ec & PF_EC_RW);
+
     MmS_SetPageMapping(rng->ctx->pt, info, phys->phys, false);
 }
 

--- a/src/oboskrnl/mm/handler.c
+++ b/src/oboskrnl/mm/handler.c
@@ -55,8 +55,8 @@ static void map_file_region(page_range* rng, uintptr_t addr, uint32_t ec, fault_
         *type = SOFT_FAULT;
         if (ec & PF_EC_RW)
             Mm_MarkAsDirtyPhys(phys);
-        MmH_RefPage(phys);
     }
+    MmH_RefPage(phys);
     info->phys = phys->phys;
     info->prot.present = true;
     info->prot.rw = rng->prot.rw && !(ec & PF_EC_RW);

--- a/src/oboskrnl/mm/initial_swap.c
+++ b/src/oboskrnl/mm/initial_swap.c
@@ -17,7 +17,6 @@
 #include <mm/alloc.h>
 
 #include <utils/tree.h>
-#include <utils/hashmap.h>
 
 #include <irq/irql.h>
 
@@ -36,31 +35,29 @@ typedef struct swap_page
     uintptr_t key;
     void* buffer;
     size_t sz;
+    RB_ENTRY(swap_page) node;
 } swap_page;
-static int swap_page_compare(const void* a_, const void* b_, void* udata)
+typedef RB_HEAD(swap_page_tree, swap_page) swap_page_tree;
+static int swap_page_compare(const swap_page* a_, const swap_page* b_)
 {
-    OBOS_UNUSED(udata);
     swap_page* a = (swap_page*)a_;
     swap_page* b = (swap_page*)b_;
     return (a->key < b->key) ? -1 : ((a->key > b->key) ? 1 : 0);
 }
-static uint64_t swap_page_hash(const void *item, uint64_t seed0, uint64_t seed1) 
-{
-    const swap_page* a = item;
-    return hashmap_sip(&a->key, sizeof(a->key), seed0, seed1);
-}
+RB_GENERATE_STATIC(swap_page_tree, swap_page, node, swap_page_compare);
+
 typedef struct swap_header
 {
     uint64_t magic;
     spinlock lock;
     long size;
     long bytesLeft;
-    struct hashmap* hashmap;
     struct {
         swap_free_handle *head, *tail;
         size_t nNodes;
         uintptr_t bump;
     } free_handles;
+    swap_page_tree pages;
 } swap_header;
 typedef struct swap_mem_tag
 {
@@ -74,13 +71,6 @@ static void* swap_malloc(size_t sz)
     tag->allocator = alloc;
     tag->sz = sz+sizeof(swap_mem_tag);
     return tag + 1;
-}
-static void* swap_realloc(void* buf, size_t sz)
-{
-    swap_mem_tag* tag = (swap_mem_tag*)buf;
-    tag--;
-    tag->sz += sz;
-    return tag->allocator->Reallocate(tag->allocator, tag, sz, tag->sz-sz, nullptr);
 }
 static void swap_libc_free(void* buf)
 {
@@ -115,11 +105,11 @@ static obos_status swap_resv(struct swap_device* dev, uintptr_t *id, bool huge_p
     }
     else
         found = hdr->free_handles.bump++;
-    swap_page pg = {};
-    pg.key = found;
-    pg.sz = sz;
-    pg.buffer = swap_malloc(sz);
-    hashmap_set(hdr->hashmap, &pg);
+    swap_page *pg = swap_malloc(sizeof(swap_page));
+    pg->key = found;
+    pg->sz = sz;
+    pg->buffer = swap_malloc(sz);
+    RB_INSERT(swap_page_tree, &hdr->pages, pg);
     hdr->bytesLeft -= sz;
     if (hdr->bytesLeft < 0)
         OBOS_Panic(OBOS_PANIC_ALLOCATOR_ERROR, "In-Ram SWAP corruption. hdr->bytesLeft < 0. bytesLeft: %ld\nThis is a bug, report it, or fix it yourself and send a PR.\n", hdr->bytesLeft);
@@ -135,15 +125,18 @@ static void swap_free_impl(void* item)
     swap_libc_free(pg->buffer);
     pg->sz = 0;
     pg->key = 0;
+    swap_libc_free(item);
 }
 static obos_status swap_free(struct swap_device* dev, uintptr_t id)
 {
     swap_header* hdr = dev->metadata;
     irql oldIrql = Core_SpinlockAcquire(&hdr->lock);
     swap_page what = {.key=id};
-    const void* item = hashmap_delete(hdr->hashmap, &what);
+    swap_page* item = RB_FIND(swap_page_tree, &hdr->pages, &what);
     if (item)
     {
+        RB_REMOVE(swap_page_tree, &hdr->pages, item);
+        swap_free_impl(item);
         hdr->bytesLeft += what.sz;
         swap_free_handle* hnd = swap_malloc(sizeof(swap_free_handle));
         memzero(hnd, sizeof(*hnd));
@@ -166,7 +159,7 @@ static obos_status swap_write(struct swap_device* dev, uintptr_t id, page* in)
     swap_header* hdr = dev->metadata;
     irql oldIrql = Core_SpinlockAcquire(&hdr->lock);
     swap_page what = {.key=id};
-    const swap_page* pg = hashmap_get(hdr->hashmap, &what);
+    const swap_page* pg = RB_FIND(swap_page_tree, &hdr->pages, &what);
     if (!pg)
     {
         Core_SpinlockRelease(&hdr->lock, oldIrql);
@@ -183,7 +176,7 @@ static obos_status swap_read(struct swap_device* dev, uintptr_t id, page* into)
     swap_header* hdr = dev->metadata;
     irql oldIrql = Core_SpinlockAcquire(&hdr->lock);
     swap_page what = {.key=id};
-    const swap_page* pg = hashmap_get(hdr->hashmap, &what);
+    const swap_page* pg = RB_FIND(swap_page_tree, &hdr->pages, &what);
     if (!pg)
     {
         Core_SpinlockRelease(&hdr->lock, oldIrql);
@@ -205,7 +198,6 @@ obos_status Mm_InitializeInitialSwapDevice(swap_dev* dev, size_t size)
     hdr->size = size-sizeof(swap_header);
     hdr->bytesLeft = hdr->size;
     hdr->lock = Core_SpinlockCreate();
-    hdr->hashmap = hashmap_new_with_allocator(swap_malloc, swap_realloc, swap_libc_free, sizeof(struct swap_allocation), 256, 0, 0, swap_page_hash, swap_page_compare, swap_free_impl, nullptr);
     dev->swap_resv = swap_resv;
     dev->swap_free = swap_free;
     dev->swap_write = swap_write;

--- a/src/oboskrnl/mm/swap.c
+++ b/src/oboskrnl/mm/swap.c
@@ -268,6 +268,12 @@ void Mm_MarkAsStandby(page_info* pg)
 void Mm_MarkAsDirtyPhys(page* node)
 {
     OBOS_ASSERT(node);
+
+    // NOTE: While this might seem like a fatal/impossible condition,
+    // stuff like fbdev use the pagecache to allow for mapping of the
+    // framebuffer from userspace.
+    if (node->flags & PHYS_PAGE_MMIO)
+        return;
  
     irql oldIrql = Core_SpinlockAcquire(&swap_lock);
     node->flags |= PHYS_PAGE_DIRTY;
@@ -287,6 +293,10 @@ void Mm_MarkAsStandbyPhys(page* node)
     OBOS_ASSERT(node);
     if (node->flags & PHYS_PAGE_STANDBY)
         return;
+    // See note for Mm_MarkAsDirtyPhys for why this is done.
+    if (node->flags & PHYS_PAGE_MMIO)
+        return;
+
     irql oldIrql = Core_SpinlockAcquire(&swap_lock);
 
     if (node->flags & PHYS_PAGE_DIRTY)

--- a/src/oboskrnl/scheduler/process.h
+++ b/src/oboskrnl/scheduler/process.h
@@ -10,6 +10,8 @@
 #include <error.h>
 #include <handle.h>
 
+#include <vfs/dirent.h>
+
 #include <locks/spinlock.h>
 #include <locks/wait.h>
 
@@ -39,6 +41,9 @@ typedef struct process
 	} children;
 	spinlock children_lock;
 	struct process *next, *prev;
+
+	dirent* cwd;
+	const char* cwd_str;
 } process;
 extern uint32_t Core_NextPID;
 

--- a/src/oboskrnl/syscall.c
+++ b/src/oboskrnl/syscall.c
@@ -249,6 +249,9 @@ uintptr_t OBOS_SyscallTable[SYSCALL_END-SYSCALL_BEGIN] = {
     (uintptr_t)Sys_SleepMS,
     (uintptr_t)Sys_Mount,
     (uintptr_t)Sys_Unmount,
+    (uintptr_t)Sys_FdCreat,
+    (uintptr_t)Sys_FdOpenEx,
+    (uintptr_t)Sys_FdOpenAtEx,
 };
 
 // Arch syscall table is defined per-arch

--- a/src/oboskrnl/syscall.c
+++ b/src/oboskrnl/syscall.c
@@ -254,6 +254,9 @@ uintptr_t OBOS_SyscallTable[SYSCALL_END-SYSCALL_BEGIN] = {
     (uintptr_t)Sys_FdOpenAtEx,
     (uintptr_t)Sys_Mkdir,
     (uintptr_t)Sys_MkdirAt,
+    (uintptr_t)Sys_Chdir,
+    (uintptr_t)Sys_ChdirEnt,
+    (uintptr_t)Sys_GetCWD,
 };
 
 // Arch syscall table is defined per-arch

--- a/src/oboskrnl/syscall.c
+++ b/src/oboskrnl/syscall.c
@@ -266,9 +266,11 @@ obos_status OBOSH_ReadUserString(const char* ustr, char* buf, size_t* sz_buf)
     context* ctx = CoreS_GetCPULocalPtr()->currentContext;
 
     obos_status status = OBOS_STATUS_SUCCESS;
-    char* kstr = Mm_MapViewOfUserMemory(ctx, (void*)ustr, nullptr, OBOS_PAGE_SIZE, OBOS_PROTECTION_READ_ONLY, true, &status);
+    // char* kstr = Mm_MapViewOfUserMemory(ctx, (void*)ustr, nullptr, OBOS_PAGE_SIZE, OBOS_PROTECTION_READ_ONLY, true, &status);
+    char* kstr = Mm_MapViewOfUserMemory(ctx, (void*)((uintptr_t)ustr - ((uintptr_t)ustr % OBOS_PAGE_SIZE)), nullptr, OBOS_PAGE_SIZE, OBOS_PROTECTION_READ_ONLY, true, &status);
     if (!kstr)
         return status;
+    kstr += ((uintptr_t)ustr % OBOS_PAGE_SIZE);
 
     char* iter = kstr;
     uintptr_t offset = (uintptr_t)kstr-(uintptr_t)iter;

--- a/src/oboskrnl/syscall.c
+++ b/src/oboskrnl/syscall.c
@@ -252,6 +252,8 @@ uintptr_t OBOS_SyscallTable[SYSCALL_END-SYSCALL_BEGIN] = {
     (uintptr_t)Sys_FdCreat,
     (uintptr_t)Sys_FdOpenEx,
     (uintptr_t)Sys_FdOpenAtEx,
+    (uintptr_t)Sys_Mkdir,
+    (uintptr_t)Sys_MkdirAt,
 };
 
 // Arch syscall table is defined per-arch

--- a/src/oboskrnl/vfs/create.c
+++ b/src/oboskrnl/vfs/create.c
@@ -1,0 +1,103 @@
+/*
+ * oboskrnl/vfs/create.c
+ *
+ * Copyright (c) 2025 Omar Berrow
+ */
+
+#include <int.h>
+#include <error.h>
+
+#include <scheduler/schedule.h>
+#include <scheduler/process.h>
+
+#include <driver_interface/header.h>
+
+#include <vfs/vnode.h>
+#include <vfs/dirent.h>
+#include <vfs/alloc.h>
+#include <vfs/mount.h>
+
+#include <utils/string.h>
+
+static bool has_write_perm(vnode* parent)
+{
+    uid current_uid = Core_GetCurrentThread()->proc->currentUID;
+    uid current_gid = Core_GetCurrentThread()->proc->currentGID;
+    if (parent->flags & VFLAGS_MOUNTPOINT)
+    {
+        drv_fs_info info = {};
+        parent->un.mounted->fs_driver->driver->header.ftable.stat_fs_info(parent->un.mounted->device, &info);
+        if (parent->owner_uid == current_uid || parent->group_uid == current_gid)
+            return ~info.flags & FS_FLAGS_RDONLY;
+        else
+            return false; 
+    }
+    if (parent->owner_uid == current_uid)
+        return parent->perm.owner_write;
+    else if (parent->group_uid == current_gid)
+        return parent->perm.group_write;
+    else
+        return parent->perm.other_write;
+}
+
+obos_status Vfs_CreateNode(dirent* parent, const char* name, uint32_t vtype, file_perm mode)
+{
+    if (!parent)
+        parent = Vfs_Root;
+    if (!name || !vtype || vtype >= VNODE_TYPE_BAD)
+        return OBOS_STATUS_INVALID_ARGUMENT;
+    vnode* parent_vn = parent->vnode;
+    if (!parent_vn)
+        return OBOS_STATUS_INVALID_ARGUMENT;
+    if (parent_vn->vtype != VNODE_TYPE_DIR)
+        return OBOS_STATUS_INVALID_ARGUMENT;
+    if (!has_write_perm(parent_vn))
+        return OBOS_STATUS_ACCESS_DENIED;
+    file_type type = 0;
+    switch (vtype)
+    {
+        case VNODE_TYPE_REG:
+            type = FILE_TYPE_REGULAR_FILE;
+            break;
+        case VNODE_TYPE_DIR:
+            type = FILE_TYPE_DIRECTORY;
+            break;
+        case VNODE_TYPE_LNK:
+            type = FILE_TYPE_SYMBOLIC_LINK;
+            break;
+        case VNODE_TYPE_BLK:
+        case VNODE_TYPE_CHR:
+        case VNODE_TYPE_SOCK:
+        case VNODE_TYPE_FIFO:
+        default:
+            return OBOS_STATUS_INVALID_ARGUMENT;
+    }
+    vnode* vn = Vfs_Calloc(1, sizeof(vnode));
+    vn->group_uid = Core_GetCurrentThread()->proc->currentGID;
+    vn->owner_uid = Core_GetCurrentThread()->proc->currentUID;
+    vn->perm = mode;
+    vn->flags = 0;
+    vn->vtype = vtype;
+    vn->refs++;
+    vn->mount_point = parent_vn->mount_point;
+    dirent* ent = Vfs_Calloc(1, sizeof(dirent));
+    OBOS_InitString(&ent->name, name);
+    ent->vnode = vn;
+    driver_ftable* ftable = &parent_vn->mount_point->fs_driver->driver->header.ftable;
+    vnode* mount_vn = nullptr;
+    if (parent_vn->flags & VFLAGS_MOUNTPOINT)
+    {
+        vn->mount_point = parent_vn->un.mounted;
+        ftable = &parent_vn->un.mounted->fs_driver->driver->header.ftable;
+        mount_vn = parent_vn->un.mounted->device;
+    }
+    obos_status status = ftable->mk_file(&vn->desc, parent_vn->flags & VFLAGS_MOUNTPOINT ? UINTPTR_MAX : parent_vn->desc, mount_vn, name, type);
+    if (obos_is_error(status))
+    {
+        Vfs_Free(vn);
+        Vfs_Free(ent);
+        return status;
+    }
+    VfsH_DirentAppendChild(parent, ent);
+    return status;
+}

--- a/src/oboskrnl/vfs/create.c
+++ b/src/oboskrnl/vfs/create.c
@@ -53,6 +53,13 @@ obos_status Vfs_CreateNode(dirent* parent, const char* name, uint32_t vtype, fil
         return OBOS_STATUS_INVALID_ARGUMENT;
     if (!has_write_perm(parent_vn))
         return OBOS_STATUS_ACCESS_DENIED;
+
+    do {
+        dirent* found = VfsH_DirentLookupFrom(name, parent);
+        if (found)
+            return OBOS_STATUS_ALREADY_INITIALIZED;
+    } while(0);
+
     file_type type = 0;
     switch (vtype)
     {

--- a/src/oboskrnl/vfs/create.h
+++ b/src/oboskrnl/vfs/create.h
@@ -21,7 +21,7 @@
     if (!(_parent))\
         _status = (OBOS_STATUS_NOT_FOUND);\
     else\
-        _status = Vfs_CreateNode(_parent, (name), (vtype), (mode));\
+        _status = Vfzs_CreateNode(_parent, (name), (vtype), (mode));\
     (_status);\
 })
 

--- a/src/oboskrnl/vfs/create.h
+++ b/src/oboskrnl/vfs/create.h
@@ -1,0 +1,28 @@
+/*
+ * oboskrnl/vfs/create.h
+ *
+ * Copyright (c) 2025 Omar Berrow
+ */
+
+#pragma once
+
+#include <int.h>
+#include <error.h>
+
+#include <driver_interface/header.h>
+
+#include <vfs/vnode.h>
+#include <vfs/dirent.h>
+
+// obos_status VfsH_CreateNodeP(const char* parent, const char* name, uint32_t vtype, file_perm mode);
+#define VfsH_CreateNodeP(parent, name, vtype, mode) ({\
+    struct dirent* _parent = VfsH_DirentLookup(parent);\
+    obos_status _status = OBOS_STATUS_SUCCESS;\
+    if (!(_parent))\
+        _status = (OBOS_STATUS_NOT_FOUND);\
+    else\
+        _status = Vfs_CreateNode(_parent, (name), (vtype), (mode));\
+    (_status);\
+})
+
+obos_status Vfs_CreateNode(dirent* parent, const char* name, uint32_t vtype, file_perm mode);

--- a/src/oboskrnl/vfs/dirent.c
+++ b/src/oboskrnl/vfs/dirent.c
@@ -109,6 +109,8 @@ dirent* VfsH_DirentLookupFrom(const char* path, dirent* root_par)
 {
     if (!path)
         return nullptr;
+    if (path[0] == 0)
+        return root_par;
     dirent* root = root_par;
     size_t path_len = strlen(path);
     if (!path_len)
@@ -176,6 +178,8 @@ dirent* VfsH_DirentLookupFrom(const char* path, dirent* root_par)
 dirent* VfsH_DirentLookup(const char* path)
 {
     dirent* root = Vfs_Root;
+    if (path[0] == 0)
+        return root;
     if (strcmp(path, "/"))
         return root;
     return VfsH_DirentLookupFrom(path, root);

--- a/src/oboskrnl/vfs/dirent.c
+++ b/src/oboskrnl/vfs/dirent.c
@@ -149,6 +149,8 @@ dirent* VfsH_DirentLookupFrom(const char* path, dirent* root_par)
         {
             if (tok[1] == '.')
                 root = root->d_parent;
+            else if (tok_len == 1)
+                OBOSS_SpinlockHint(); // this token is just a '.', so we need to ignore the next else if.
             else if (tok[1] != 0)
                 goto down;
             const char *newtok = tok + str_search(tok, '/');

--- a/src/oboskrnl/vfs/dirent.c
+++ b/src/oboskrnl/vfs/dirent.c
@@ -435,6 +435,8 @@ obos_status VfsH_Chdir(void* target_, const char *path)
     if (!ent)
         return OBOS_STATUS_NOT_FOUND;
     
+    Vfs_Free((char*)target->cwd_str);
+    
     target->cwd = ent;
     target->cwd_str = realpath(ent);
     
@@ -446,6 +448,8 @@ obos_status VfsH_ChdirEnt(void* /* struct process */ target_, dirent* ent)
     if (!ent || !target)
         return OBOS_STATUS_INVALID_ARGUMENT;
     
+    Vfs_Free((char*)target->cwd_str);
+
     target->cwd = ent;
     target->cwd_str = realpath(ent);
     

--- a/src/oboskrnl/vfs/dirent.h
+++ b/src/oboskrnl/vfs/dirent.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <int.h>
+#include <error.h>
 
 #include <vfs/limits.h>
 
@@ -43,6 +44,8 @@ void VfsH_DirentRemoveChild(dirent* parent, dirent* what);
 // the lookup
 dirent* VfsH_DirentLookup(const char* path);
 dirent* VfsH_DirentLookupFrom(const char* path, dirent* root);
+obos_status VfsH_Chdir(void* /* struct process */ target, const char *path);
+obos_status VfsH_ChdirEnt(void* /* struct process */ target, dirent* ent);
 
 OBOS_EXPORT dirent* Drv_RegisterVNode(struct vnode* vn, const char* const dev_name);
 

--- a/src/oboskrnl/vfs/fd.c
+++ b/src/oboskrnl/vfs/fd.c
@@ -161,7 +161,8 @@ obos_status Vfs_FdWrite(fd* desc, const void* buf, size_t nBytes, size_t* nWritt
         size_t offset = desc->offset;
         for (size_t i = 0; bytesLeft; i += OBOS_PAGE_SIZE)
         {
-            uint8_t* ent = VfsH_PageCacheGetEntry(desc->vn, desc->offset+i, true);
+            page* pg = nullptr;
+            uint8_t* ent = VfsH_PageCacheGetEntry(desc->vn, desc->offset+i, &pg);
             if (!ent)
             {
                 status = OBOS_STATUS_INTERNAL_ERROR;
@@ -173,6 +174,7 @@ obos_status Vfs_FdWrite(fd* desc, const void* buf, size_t nBytes, size_t* nWritt
             else
                 bytesLeft = 0;
             offset += OBOS_PAGE_SIZE;
+            Mm_MarkAsDirtyPhys(pg);
         }
         done:
         VfsH_UnlockMountpoint(point);
@@ -244,7 +246,7 @@ obos_status Vfs_FdRead(fd* desc, void* buf, size_t nBytes, size_t* nRead)
         // for (volatile bool b = (nBytes==0x2918); b; );
         while (bytesLeft)
         {
-            const uint8_t* ent = VfsH_PageCacheGetEntry(desc->vn, offset, false);
+            const uint8_t* ent = VfsH_PageCacheGetEntry(desc->vn, offset, nullptr);
             if (!ent)
             {
                 status = OBOS_STATUS_INTERNAL_ERROR;

--- a/src/oboskrnl/vfs/fd.c
+++ b/src/oboskrnl/vfs/fd.c
@@ -161,7 +161,7 @@ obos_status Vfs_FdWrite(fd* desc, const void* buf, size_t nBytes, size_t* nWritt
         size_t offset = desc->offset;
         for (size_t i = 0; bytesLeft; i += OBOS_PAGE_SIZE)
         {
-            uint8_t* ent = VfsH_PageCacheGetEntry(desc->vn, desc->offset+i, false);
+            uint8_t* ent = VfsH_PageCacheGetEntry(desc->vn, desc->offset+i, true);
             if (!ent)
             {
                 status = OBOS_STATUS_INTERNAL_ERROR;

--- a/src/oboskrnl/vfs/fd.c
+++ b/src/oboskrnl/vfs/fd.c
@@ -364,7 +364,7 @@ obos_status Vfs_FdIoctl(fd* desc, uint64_t request, void* argp)
         return OBOS_STATUS_UNINITIALIZED;
     if (desc->vn->vtype != VNODE_TYPE_BLK && desc->vn->vtype != VNODE_TYPE_CHR)
         return OBOS_STATUS_INVALID_IOCTL;
-    return desc->vn->un.device->driver->header.ftable.ioctl(desc->vn->un.device->desc, request, argp);
+    return desc->vn->un.device->driver->header.ftable.ioctl(desc->vn->desc, request, argp);
 }
 obos_status Vfs_FdFlush(fd* desc)
 {

--- a/src/oboskrnl/vfs/fd.h
+++ b/src/oboskrnl/vfs/fd.h
@@ -32,6 +32,8 @@ enum
     FD_OFLAGS_WRITE = 2,
     FD_OFLAGS_UNCACHED = 4,
     FD_OFLAGS_NOEXEC = 8,
+    // NOTE: Only handled in syscalls, and is ignored in Vfs_FdOpen*.
+    FD_OFLAGS_CREATE = 16,
 };
 typedef struct fd
 {

--- a/src/oboskrnl/vfs/fd_sys.c
+++ b/src/oboskrnl/vfs/fd_sys.c
@@ -109,7 +109,7 @@ obos_status Sys_FdOpenEx(handle desc, const char* upath, uint32_t oflags, uint32
             return OBOS_STATUS_NOT_FOUND; // parent wasn't found.
         }
         file_perm real_mode = unix_to_obos_mode(mode);
-        status = Vfs_CreateNode(parent, path+(index == sz_path ? 0 : index), VNODE_TYPE_REG, real_mode);
+        status = Vfs_CreateNode(parent, path+(index == sz_path ? 0 : index+1), VNODE_TYPE_REG, real_mode);
     }
     Free(OBOS_KernelAllocator, path, sz_path);
     return status;
@@ -445,7 +445,25 @@ obos_status Sys_Stat(int fsfdt, handle desc, const char* upath, int flags, struc
     driver->ftable.get_blk_size(to_stat->desc, &blkSize);
     driver->ftable.get_max_blk_count(to_stat->desc, &blocks);
     st.st_blksize = blkSize;
-    st.st_mode = *(uint16_t*)&to_stat->perm;
+    st.st_mode = 0;
+    if (to_stat->perm.owner_read)
+        st.st_mode |= 400;
+    if (to_stat->perm.owner_write)
+        st.st_mode |= 200;
+    if (to_stat->perm.owner_exec)
+        st.st_mode |= 100;
+    if (to_stat->perm.group_read)
+        st.st_mode |= 040;
+    if (to_stat->perm.group_write)
+        st.st_mode |= 020;
+    if (to_stat->perm.group_exec)
+        st.st_mode |= 010;
+    if (to_stat->perm.other_read)
+        st.st_mode |= 004;
+    if (to_stat->perm.other_write)
+        st.st_mode |= 002;
+    if (to_stat->perm.other_exec)
+        st.st_mode |= 001;
     switch (to_stat->vtype) {
         case VNODE_TYPE_DIR:
             st.st_mode |= S_IFDIR;
@@ -619,7 +637,7 @@ obos_status Sys_Mkdir(const char* upath, uint32_t mode)
         return OBOS_STATUS_NOT_FOUND; // parent wasn't found.
     }
     file_perm real_mode = unix_to_obos_mode(mode);
-    status = Vfs_CreateNode(parent, path+(index == sz_path ? 0 : index), VNODE_TYPE_REG, real_mode);
+    status = Vfs_CreateNode(parent, path+(index == sz_path ? 0 : index+1), VNODE_TYPE_DIR, real_mode);
     Free(OBOS_KernelAllocator, path, sz_path);
     return status;
 }

--- a/src/oboskrnl/vfs/fd_sys.h
+++ b/src/oboskrnl/vfs/fd_sys.h
@@ -16,9 +16,12 @@
 
 handle Sys_FdAlloc();
 
-obos_status       Sys_FdOpen(handle desc, const char* path, uint32_t oflags);
-obos_status Sys_FdOpenDirent(handle desc, handle ent, uint32_t oflags);
-obos_status     Sys_FdOpenAt(handle desc, handle ent, const char* name, uint32_t oflags);
+obos_status         Sys_FdOpen(handle desc, const char* path, uint32_t oflags);
+obos_status       Sys_FdOpenEx(handle desc, const char* path, uint32_t oflags, uint32_t mode);
+obos_status   Sys_FdOpenDirent(handle desc, handle ent, uint32_t oflags);
+obos_status       Sys_FdOpenAt(handle desc, handle ent, const char* name, uint32_t oflags);
+obos_status     Sys_FdOpenAtEx(handle desc, handle ent, const char* name, uint32_t oflags, uint32_t mode);
+obos_status     Sys_FdCreat(handle desc, const char* name, uint32_t mode);
 
 obos_status Sys_FdWrite(handle desc, const void* buf, size_t nBytes, size_t* nWritten);
 obos_status  Sys_FdRead(handle desc, void* buf, size_t nBytes, size_t* nRead);

--- a/src/oboskrnl/vfs/fd_sys.h
+++ b/src/oboskrnl/vfs/fd_sys.h
@@ -82,3 +82,7 @@ void OBOS_OpenStandardFDs(struct handle_table* tbl);
 
 obos_status Sys_Mount(const char* at, const char* on);
 obos_status Sys_Unmount(const char* at);
+
+obos_status Sys_Chdir(const char *path);
+obos_status Sys_ChdirEnt(handle ent);
+obos_status Sys_GetCWD(char* path, size_t len);

--- a/src/oboskrnl/vfs/fd_sys.h
+++ b/src/oboskrnl/vfs/fd_sys.h
@@ -22,6 +22,8 @@ obos_status   Sys_FdOpenDirent(handle desc, handle ent, uint32_t oflags);
 obos_status       Sys_FdOpenAt(handle desc, handle ent, const char* name, uint32_t oflags);
 obos_status     Sys_FdOpenAtEx(handle desc, handle ent, const char* name, uint32_t oflags, uint32_t mode);
 obos_status     Sys_FdCreat(handle desc, const char* name, uint32_t mode);
+obos_status     Sys_Mkdir(const char* name, uint32_t mode);
+obos_status     Sys_MkdirAt(handle dirent, const char* name, uint32_t mode);
 
 obos_status Sys_FdWrite(handle desc, const void* buf, size_t nBytes, size_t* nWritten);
 obos_status  Sys_FdRead(handle desc, void* buf, size_t nBytes, size_t* nRead);

--- a/src/oboskrnl/vfs/mount.c
+++ b/src/oboskrnl/vfs/mount.c
@@ -378,7 +378,7 @@ obos_status Vfs_StatFSInfo(struct vnode* vn, struct drv_fs_info* out)
 {
     if (!vn)
         return OBOS_STATUS_INVALID_ARGUMENT;
-    if (vn->flags & VFLAGS_MOUNTPOINT || !out)
+    if (~vn->flags & VFLAGS_MOUNTPOINT || !out)
         return OBOS_STATUS_INVALID_ARGUMENT;
     return vn->un.mounted->fs_driver->driver->header.ftable.stat_fs_info(vn->un.mounted->device, out);
 }


### PR DESCRIPTION
- **vfs: Add file+directory creation ability.**
- **initial_swap: Fix bugs related to hangs.**
- **misc/x86_64: Fix a LTO warning.**
- **fat: Fix a bug with dirent creation.**
- **misc: Add vfs/create.c to build.**
- **vfs: Fix a bug with Vfs_StatFSInfo**
- **mm: Fix bugs with the page cache.**
- **vfs: Fix a bug with writing files.**
- **x86_64: Remove unwanted code from entry.c**
- **sys: Add file creation capability to VFS syscalls.**
- **sys: Fix use-after-free of path in Sys_FdOpenEx.**
- **ps2: Fix bug where an event was being set at an invalid IRQL**
- **vfs: Check for file existance before creating the file in Vfs_CreateNode.**
- **sys: Add Sys_Mkdir and Sys_MkdirAt syscalls.**
- **misc: Bug fixes where EFAULT would be wrongfully returned.**
- **fat: Fix compiler warnings related to the structs fat_date and fat_time.**
- **sys: Fix bugs in Sys_FdOpenEx and Sys_Mkdir.**
- **mm: Fix pagecache bugs.**
- **vfs: Fix a bug in dirent lookups.**
- **mm: Change page cache to require the caller to mark the page as dirty to avoid race conditions.**
- **drv: Change signature of move_desc_to.**
- **vfs: Implement working directories.**
- **misc: Add syscalls to syscall to name table.**
- **core: Make process inherit their parent's working directory.**
- **sys: Fix bug in Sys_FdOpenEx.**
- **x86_64: Fix typo.**
- **fd: Fix bugs with cached reads and writes.**
- **libps2: Fix bug with get_readable_count.**
- **misc: Add fbdev at /dev/fb0.**
- **sys: Fix a bug in Sys_ThreadPriority**
- **fat: Remove debug log**
- **sys: Fixes in Sys_SleepMS**
- **fat: Use the pagecache in write_sync instead of Vfs_Fd* APIs.**
- **x86_64: Fix a bug in MmS_QueryPageInfo.**
- **x86_64: Speed up CoreS_TImerFrequency to 2000hz from 500hz**
- **vfs: Fix a bug when './' is used in a path**
- **sys: Fix a bug with Sys_Mkdir**
