### PR TITLE
TTY Support

### DIFF
--- a/src/oboskrnl/CMakeLists.txt
+++ b/src/oboskrnl/CMakeLists.txt
@@ -19,7 +19,7 @@ list (APPEND oboskrnl_sources
 	"mm/fork.c" "power/suspend.c" "power/device.c" "power/init.c"
 	"driver_interface/pci.c" "utils/shared_ptr.c" "locks/sys_futex.c" "vfs/fd_sys.c"
 	"elf/load.c" "driver_interface/drv_sys.c" "sig_sys.c" "execve.c"
-	"init_proc.c" "vfs/create.c"
+	"init_proc.c" "vfs/create.c" "vfs/tty.c"
 )
 
 add_executable(oboskrnl)

--- a/src/oboskrnl/arch/x86_64/syscall.c
+++ b/src/oboskrnl/arch/x86_64/syscall.c
@@ -189,6 +189,10 @@ const char* syscall_to_string[] = {
     "Sys_Chdir",
     "Sys_ChdirEnt",
     "Sys_GetCWD",
+    "Sys_SetControllingTTY",
+    "Sys_GetControllingTTY",
+    "Sys_TTYName",
+    "Sys_IsATTY",
 };
 
 void Arch_LogSyscall(uintptr_t rdi, uintptr_t rsi, uintptr_t rdx, uintptr_t r8, uintptr_t r9, uint32_t eax)

--- a/src/oboskrnl/arch/x86_64/thread_ctx.asm
+++ b/src/oboskrnl/arch/x86_64/thread_ctx.asm
@@ -53,6 +53,7 @@ align 8
 .frame: resq 0x1b
 .stackBase: resq 1
 .stackSize: resq 1
+.signal_extended_ctx_ptr: resq 1
 endstruc
 
 extern Core_GetIRQLVar
@@ -144,8 +145,14 @@ CoreS_FreeThreadContext:
 	push rbp
 	mov rbp, rsp
 
+	push rdi
 	mov rdi, [rdi+thread_ctx.extended_ctx_ptr]
 	call Arch_FreeXSAVERegion
+	pop rdi
+	push rdi
+	mov rdi, [rdi+thread_ctx.signal_extended_ctx_ptr]
+	call Arch_FreeXSAVERegion
+	pop rdi
 
 	xor rax,rax ; OBOS_STATUS_SUCCESS
 

--- a/src/oboskrnl/arch/x86_64/thread_ctx.h
+++ b/src/oboskrnl/arch/x86_64/thread_ctx.h
@@ -21,6 +21,7 @@ struct thread_context_info
 	interrupt_frame frame;
 	void* stackBase;
 	size_t stackSize;
+	void* signal_extended_ctx_ptr;
 } OBOS_ALIGN(8);
 
 extern void Arch_UserYield(void* kstck);

--- a/src/oboskrnl/driver_interface/header.h
+++ b/src/oboskrnl/driver_interface/header.h
@@ -135,6 +135,7 @@ typedef struct driver_ftable
     obos_status(*query_user_readable_name)(dev_desc what, const char** name); // unrequired for fs drivers.
     // The driver dictates what the request means, and what its parameters are.
     obos_status(*ioctl)(dev_desc what, uint32_t request, void* argp);
+    obos_status(*ioctl_argp_size)(uint32_t request, size_t* ret);
     // Called on driver unload.
     // Frees all the driver's allocated resources, as the kernel 
     // does not keep a track of allocated resources, and cannot free them on driver unload, causing a

--- a/src/oboskrnl/error.h
+++ b/src/oboskrnl/error.h
@@ -152,7 +152,7 @@ typedef enum
 	OBOS_STATUS_PIPE_CLOSED,
 	/// <summary>
 	/// Returned if the write request could not be completed, as there is simply not enough space in the device<para/>
-	/// For example, this can happen if the size of a write to a pipe is greater than the pipe's size.'
+	/// For example, this can happen if the size of a write to a pipe is greater than the pipe's size.
 	/// </summary>
 	OBOS_STATUS_NO_SPACE,
 	/// <summary>
@@ -171,4 +171,8 @@ typedef enum
 	/// The operation would block.
 	/// </summary>
 	OBOS_STATUS_WOULD_BLOCK,
+	/// <summary>
+	/// The passed file or handle is not a TTY.
+	/// </summary>
+	OBOS_STATUS_NOT_A_TTY,
 } obos_status;

--- a/src/oboskrnl/scheduler/process.h
+++ b/src/oboskrnl/scheduler/process.h
@@ -12,6 +12,8 @@
 
 #include <vfs/dirent.h>
 
+#include <vfs/tty.h>
+
 #include <locks/spinlock.h>
 #include <locks/wait.h>
 
@@ -44,6 +46,8 @@ typedef struct process
 
 	dirent* cwd;
 	const char* cwd_str;
+
+	tty* controlling_tty;
 } process;
 extern uint32_t Core_NextPID;
 

--- a/src/oboskrnl/scheduler/sched_sys.c
+++ b/src/oboskrnl/scheduler/sched_sys.c
@@ -577,7 +577,7 @@ obos_status Sys_WaitProcess(handle proc, int* wstatus, int options, uint32_t* pi
         process = Core_GetCurrentThread()->proc->children.head;
         while (process && process->dead)
             process = process->next;
-        status = process ? OBOS_STATUS_NOT_FOUND : OBOS_STATUS_SUCCESS;
+        status = process ? OBOS_STATUS_SUCCESS : OBOS_STATUS_NOT_FOUND;
         if (!process)
             return status;
         process->refcount++;

--- a/src/oboskrnl/scheduler/schedule.c
+++ b/src/oboskrnl/scheduler/schedule.c
@@ -4,6 +4,7 @@
  * Copyright (c) 2024-2025 Omar Berrow
  */
 
+#include "signal.h"
 #include <int.h>
 #include <klog.h>
 
@@ -162,6 +163,13 @@ void Core_Yield()
 			return; // No rescheduling needed, as the thread's quantum isn't finished yet.
 		}
 		CoreS_SaveRegisterContextAndYield(&getCurrentThread->context);
+// #ifdef __x86_64__
+// 		if (OBOS_SyncPendingSignal(&getCurrentThread->context.frame))
+// 		{
+// 			getCurrentThread->context.cr3 = getCurrentThread->context.frame.cr3;
+// 			CoreS_SwitchToThreadContext(&getCurrentThread->context);
+// 		}
+// #endif
 		if (oldIrql != IRQL_INVALID)
 		{
 			OBOS_ASSERT(!(oldIrql & ~0xf));

--- a/src/oboskrnl/scheduler/thread.h
+++ b/src/oboskrnl/scheduler/thread.h
@@ -103,6 +103,7 @@ typedef struct thread
 	struct signal_header* signal_info;
 
 	void* kernelStack; // size: 0x10000 bytes
+	void* userStack; // size: 0x10000 bytes, used for signals dispatched in kernel-mode.
 
 	// Thread profiling info
 

--- a/src/oboskrnl/signal.h
+++ b/src/oboskrnl/signal.h
@@ -111,14 +111,16 @@ enum {
 obos_status OBOS_SigProcMask(int how, const sigset_t* mask, sigset_t* oldset);
 obos_status OBOS_SigAltStack(const uintptr_t* sp, uintptr_t* oldsp);
 
+obos_status OBOS_KillProcess(struct process* proc, int sigval);
+
 typedef struct thread_context_info ucontext_t;
 
-void OBOS_SyncPendingSignal(interrupt_frame* frame);
+bool OBOS_SyncPendingSignal(interrupt_frame* frame);
 void OBOS_RunSignal(int sigval, interrupt_frame* frame);
 
 // NOTE: This function is implemented as if it is a syscall,
 // i.e., frame is `memcpy_usr_to_k`ed to a kernel buffer.
-OBOS_WEAK void OBOSS_SigReturn(interrupt_frame* frame);
+OBOS_WEAK void OBOSS_SigReturn(ucontext_t* frame);
 
 OBOS_WEAK void OBOSS_RunSignalImpl(int sigval, interrupt_frame* frame);
 

--- a/src/oboskrnl/text.c
+++ b/src/oboskrnl/text.c
@@ -120,6 +120,12 @@ obos_status OBOS_WriteCharacter(text_renderer_state* state, char ch)
 {
 	if (!state->fb.base)
 		return OBOS_STATUS_INVALID_INIT_PHASE;
+	if (ch < 0x20 && ch != '\r' && ch != '\n' && ch != '\t' && ch != '\b')
+	{
+		OBOS_WriteCharacter(state, '^');
+		OBOS_WriteCharacter(state, ch+0x40);
+		return OBOS_STATUS_SUCCESS;
+	}
 	switch (ch)
 	{
 	case '\n':
@@ -132,6 +138,7 @@ obos_status OBOS_WriteCharacter(text_renderer_state* state, char ch)
 		state->column += 4 - (state->column % 4);
 		break;
 	case '\b':
+	case '\177':
 		if (!state->column)
 			break;
 		putch(state, ' ', --state->column, state->row, state->fg_color, OBOS_TEXT_BACKGROUND);

--- a/src/oboskrnl/vfs/fd.c
+++ b/src/oboskrnl/vfs/fd.c
@@ -212,10 +212,11 @@ static obos_status do_uncached_read(fd* desc, void* into, size_t nBytes, size_t*
     nBytes /= blkSize;
     const size_t base_offset = desc->vn->flags & VFLAGS_PARTITION ? desc->vn->partitions[0].off : 0;
     const uintptr_t offset = (desc->offset+base_offset) / blkSize;
-    if (!VfsH_LockMountpoint(point))
+    if (desc->vn->vtype == VNODE_TYPE_REG && !VfsH_LockMountpoint(point))
         return OBOS_STATUS_ABORTED;
     obos_status status = driver->ftable.read_sync(desc->vn->desc, into, nBytes, offset, nRead_);
-    VfsH_UnlockMountpoint(point);
+    if (desc->vn->vtype == VNODE_TYPE_REG)
+        VfsH_UnlockMountpoint(point);
     if (obos_expect(obos_is_error(status) == true, 0))
         return status;
     if (nRead_)

--- a/src/oboskrnl/vfs/fd_sys.h
+++ b/src/oboskrnl/vfs/fd_sys.h
@@ -9,6 +9,7 @@
 #include <int.h>
 #include <error.h>
 #include <handle.h>
+#include <signal.h>
 
 #include <vfs/limits.h>
 
@@ -86,3 +87,13 @@ obos_status Sys_Unmount(const char* at);
 obos_status Sys_Chdir(const char *path);
 obos_status Sys_ChdirEnt(handle ent);
 obos_status Sys_GetCWD(char* path, size_t len);
+
+// Stay tuned for this...
+// struct pselect_extra_args
+// {
+//     const uintptr_t* timeout;
+//     const sigset_t* sigmask;
+//     size_t* num_events;
+// };
+
+// obos_status Sys_PSelect(size_t nFds, uint8_t* read_set, uint8_t *write_set, uint8_t *except_set, const struct pselect_extra_args* extra);

--- a/src/oboskrnl/vfs/tty.c
+++ b/src/oboskrnl/vfs/tty.c
@@ -1,0 +1,633 @@
+/*
+ * oboskrnl/vfs/tty.c
+ *
+ * Copyright (c) 2025 Omar Berrow
+ */
+
+#include <int.h>
+#include <error.h>
+#include <klog.h>
+#include <text.h>
+#include <signal.h>
+#include <memmanip.h>
+
+#include <driver_interface/driverId.h>
+#include <driver_interface/header.h>
+
+#include <scheduler/thread.h>
+#include <scheduler/process.h>
+#include <scheduler/schedule.h>
+#include <scheduler/thread_context_info.h>
+
+#include <mm/alloc.h>
+#include <mm/context.h>
+
+#include <irq/timer.h>
+
+#include <vfs/alloc.h>
+#include <vfs/dirent.h>
+#include <vfs/keycode.h>
+#include <vfs/tty.h>
+#include <vfs/vnode.h>
+#include <vfs/fd.h>
+
+static obos_status tty_get_blk_size(dev_desc ign, size_t *sz)
+{
+    OBOS_UNUSED(ign);
+    if (!sz)
+        return OBOS_STATUS_INVALID_ARGUMENT;
+    *sz = 1;
+    return OBOS_STATUS_SUCCESS;
+}
+static obos_status tty_get_max_blk_count(dev_desc ign1, size_t *ign2) 
+{
+    OBOS_UNUSED(ign1);
+    OBOS_UNUSED(ign2);
+    return OBOS_STATUS_INVALID_OPERATION;
+}
+
+static inline size_t find_eol(tty* t, volatile const char* buf)
+{
+    size_t i = 0;
+    for (; buf[i]; i++)
+    {
+        if (buf[i] == '\n' ||
+            buf[i] == '\r' ||
+            buf[i] == t->termios.cc[VEOL] ||
+            buf[i] == t->termios.cc[VEOL2])
+            return i;
+    }
+    return SIZE_MAX;
+}
+
+static obos_status tty_read_sync(dev_desc desc, void *buf, size_t blkCount,
+                                 size_t blkOffset, size_t *nBlkRead) 
+{
+    OBOS_UNUSED(blkOffset);
+
+    tty *tty = (struct tty *)desc;
+    if (!tty || tty->magic != TTY_MAGIC)
+        return OBOS_STATUS_INVALID_ARGUMENT;
+
+    obos_status status = OBOS_STATUS_SUCCESS;
+    uint8_t *out_buf = buf;
+    if (tty->termios.lflag & ICANON)
+    {
+        // Read until the next EOL (Either '\n', '\r', VEOL, or VEOL2)
+        // size_t i = 0;
+        // for (; i < blkCount; i++)
+        // {
+        //     while (tty->input_buffer.in_ptr >= tty->input_buffer.out_ptr)
+        //         OBOSS_SpinlockHint();
+        //     char ch = tty->input_buffer.buf[tty->input_buffer.in_ptr++];
+        //     if (ch == '\n' || ch == '\r' || ch == tty->termios.cc[VEOL] || ch == tty->termios.cc[VEOL2])
+        //         break;
+        //     out_buf[i] = ch;
+        // }
+        size_t nBytesRead = 0;
+        do {
+            nBytesRead = find_eol(tty, tty->input_buffer.buf+tty->input_buffer.in_ptr);
+            if (nBytesRead == SIZE_MAX)
+                Core_Yield();
+        } while(nBytesRead == SIZE_MAX);
+        nBytesRead++;
+        nBytesRead = OBOS_MIN(blkCount, nBytesRead);
+        memcpy(out_buf, tty->input_buffer.buf+tty->input_buffer.in_ptr, nBytesRead);
+        tty->input_buffer.in_ptr += nBytesRead;
+        if (nBlkRead)
+            *nBlkRead = nBytesRead;
+    }
+    else 
+    {
+        // Read until blkCount or VMIN bytes are read, or until VTIME is exceeded.
+        timer_tick deadline = CoreS_GetTimerTick()+CoreH_TimeFrameToTick(tty->termios.cc[VTIME]*100000);
+        size_t i = 0;
+        for (; i < blkCount && i < tty->termios.cc[VMIN]; i++)
+        {
+            while (CoreS_GetTimerTick() > deadline && (tty->input_buffer.in_ptr == tty->input_buffer.out_ptr))
+                OBOSS_SpinlockHint();
+            if (CoreS_GetTimerTick() > deadline)
+            {
+                status = OBOS_STATUS_TIMED_OUT;
+                break;
+            }
+            out_buf[i] = tty->input_buffer.buf[tty->input_buffer.in_ptr++];
+        }
+        if (nBlkRead)
+            *nBlkRead = i;
+    }
+
+
+    return status;
+}
+
+static char toupper(char ch) 
+{
+    if (ch >= 'a' && ch <= 'z')
+        return (ch - 'a') + 'A';
+    return ch;
+}
+
+static obos_status tty_write_sync(dev_desc desc, const void *buf,
+                                  size_t blkCount, size_t blkOffset,
+                                  size_t *nBlkWritten) {
+    OBOS_UNUSED(blkOffset);
+
+    tty *tty = (struct tty *)desc;
+    if (!tty || tty->magic != TTY_MAGIC)
+        return OBOS_STATUS_INVALID_ARGUMENT;
+    obos_status status = OBOS_STATUS_SUCCESS;
+    if (!tty->termios.oflag)
+        status = tty->interface.write(tty, buf, blkCount);
+    else 
+    {
+        const char *str = buf;
+        for (size_t i = 0; i < blkCount; i++) {
+        switch (str[i]) {
+            case '\n': {
+                if (tty->termios.oflag & ONLCR)
+                    status = tty->interface.write(tty, "\r\n", 2);
+                else if (tty->termios.oflag & ONLRET)
+                    ; // TODO: Implement.
+                else
+                    status = tty->interface.write(tty, "\n", 1);
+                break;
+            }
+            case '\r': {
+                if (tty->termios.oflag & OCRNL)
+                    status = tty->interface.write(tty, "\n", 1);
+                else
+                    status = tty->interface.write(tty, "\r", 1);
+                break;
+            }
+            default:
+                if (tty->termios.oflag & OLCUC) 
+                {
+                    char ch = toupper(str[i]);
+                    status = tty->interface.write(tty, &ch, 1);
+                    break;
+                }
+                status = tty->interface.write(tty, str, 1);
+                break;
+            }
+            if (obos_is_error(status)) {
+                if (nBlkWritten)
+                    *nBlkWritten = i;
+                return status;
+            }
+        }
+    }
+    if (nBlkWritten)
+        *nBlkWritten = blkCount;
+    return status;
+}
+
+static obos_status tty_ioctl_argp_size(uint32_t request, size_t *ret) 
+{
+    if (!ret)
+        return OBOS_STATUS_INVALID_ARGUMENT;
+    obos_status status = OBOS_STATUS_SUCCESS;
+    switch (request)
+    {
+        case TTY_IOCTL_SETATTR:
+        case TTY_IOCTL_GETATTR:
+            *ret = sizeof(struct termios);
+            break;
+        case TTY_IOCTL_DRAIN:
+            *ret = 0;
+            break;
+        case TTY_IOCTL_FLOW:
+        case TTY_IOCTL_FLUSH:
+            *ret = 0;
+            status = OBOS_STATUS_UNIMPLEMENTED;
+            break;
+        default: 
+            *ret = 0;
+            status = OBOS_STATUS_INVALID_IOCTL;
+            break;
+    }
+    return status;
+}
+static obos_status tty_ioctl(dev_desc what, uint32_t request, void *argp) 
+{
+    tty *tty = (struct tty *)what;
+    if (!tty)
+        return OBOS_STATUS_INVALID_ARGUMENT;
+    if (tty->magic != TTY_MAGIC)
+        return OBOS_STATUS_NOT_A_TTY;
+    obos_status status = OBOS_STATUS_SUCCESS;
+    switch (request) {
+        case TTY_IOCTL_SETATTR:
+            memcpy(&tty->termios, argp, sizeof(struct termios));
+            break;
+        case TTY_IOCTL_GETATTR:
+            memcpy(argp, &tty->termios, sizeof(struct termios));
+            break;
+        case TTY_IOCTL_FLOW:
+        case TTY_IOCTL_FLUSH:
+            status = OBOS_STATUS_UNIMPLEMENTED;
+            break;
+        // "tcdrain() waits until all output written to the object referred to by fd has been transmitted."
+        // We always immediately transmit data.
+        case TTY_IOCTL_DRAIN:
+            status = OBOS_STATUS_SUCCESS;
+            break;
+        default:
+            status = OBOS_STATUS_INVALID_IOCTL;
+    }
+    return status;
+}
+
+static size_t last_tty_index = 0;
+static size_t last_pty_index = 0;
+
+driver_id OBOS_TTYDriver = {
+    .id = 0,
+    .header = {.magic = OBOS_DRIVER_MAGIC,
+               .flags = DRIVER_HEADER_FLAGS_NO_ENTRY |
+                        DRIVER_HEADER_HAS_VERSION_FIELD |
+                        DRIVER_HEADER_HAS_STANDARD_INTERFACES,
+               .ftable =
+                   {
+                       .get_blk_size = tty_get_blk_size,
+                       .get_max_blk_count = tty_get_max_blk_count,
+                       .write_sync = tty_write_sync,
+                       .read_sync = tty_read_sync,
+                       .ioctl = tty_ioctl,
+                       .ioctl_argp_size = tty_ioctl_argp_size,
+                       .driver_cleanup_callback = nullptr,
+                   },
+               .driverName = "TTY Driver"}};
+
+uint8_t default_control[32] = {
+    [VINTR] = '\003',    [VQUIT] = '\034', [VERASE] = '\177', [VKILL] = '\025',
+    [VEOF] = '\004',     [VTIME] = '\000', [VMIN] = '\000',   [VSWTC] = '\000',
+    [VSTART] = '\021', // Only recognized when IXON is set.
+    [VSTOP] = '\023',  // Only recognized when IXON is set.
+    [VSUSP] = '\032',    [VEOL] = '\000',
+    [VREPRINT] = '\022', // Only recognized when ICANON and IEXTEN are set
+    [VDISCARD] = '\017', // Only recognized when IEXTEN is set
+    [VWERASE] = '\027',
+    [VLNEXT] = '\017', // Only recognized when IEXTEN is set
+    [VEOL2] = '\000',
+};
+
+static size_t strrfind(const char* str, char ch)
+{
+    int64_t i = strlen(str);
+    for (; i >= 0; i--)
+        if (str[i] == ch)
+           return i;
+    return SIZE_MAX;
+}
+
+void erase_bytes(tty* tty, size_t nBytesToErase)
+{
+    if (nBytesToErase == SIZE_MAX)
+        nBytesToErase = tty->input_buffer.out_ptr % tty->input_buffer.size;
+    for (size_t j = 0; j < nBytesToErase && tty->input_buffer.out_ptr > 0; j++)
+    {
+        tty->input_buffer.buf[--tty->input_buffer.out_ptr % tty->input_buffer.size] = 0;
+        tty->interface.write(tty, "\b", 1);
+    }
+}
+
+static void tty_kill(tty* tty, int sigval)
+{
+    if (tty->termios.lflag & ISIG)
+        OBOS_KillProcess(tty->fg_job, sigval);
+}
+
+static void data_ready(void *tty_, const void *buf, size_t nBytesReady) {
+    tty *tty = (struct tty *)tty_;
+    const uint8_t *buf8 = buf;
+    for (size_t i = 0; i < nBytesReady; i++) 
+    {
+        bool insert_byte = true;
+        if (!tty->quoted) 
+        {
+            insert_byte = false;
+            if (buf8[i] == tty->termios.cc[VLNEXT] && (tty->termios.lflag & (ICANON|IEXTEN)))
+                insert_byte = !(tty->quoted = true);
+            else
+                tty->quoted = false;
+            if (buf8[i] == tty->termios.cc[VINTR])
+                tty_kill(tty, SIGINT);
+            else if (buf8[i] == tty->termios.cc[VQUIT])
+                tty_kill(tty, SIGQUIT);
+            else if (buf8[i] == tty->termios.cc[VSUSP])
+                tty_kill(tty, SIGTSTP);
+            else
+                insert_byte = true;
+            if ((buf8[i] == tty->termios.cc[VERASE] || buf8[i] == tty->termios.cc[VWERASE]) && (tty->termios.lflag & (ICANON|ECHOE)))
+            {
+                size_t nBytesToErase = buf8[i] == tty->termios.cc[VERASE] ? 1 : 0;
+                if (nBytesToErase == 0)
+                {
+                    size_t index_space = strrfind(tty->input_buffer.buf, ' ');
+                    if (index_space != SIZE_MAX)
+                        nBytesToErase = tty->input_buffer.out_ptr - index_space - 1;
+                    size_t last_ln = strrfind(tty->input_buffer.buf, '\n');
+                    if (last_ln > index_space && last_ln != SIZE_MAX)
+                        nBytesToErase = tty->input_buffer.out_ptr - last_ln - 1;
+                }
+                if ((~tty->termios.lflag & IEXTEN) && buf8[i] == tty->termios.cc[VWERASE])
+                    nBytesToErase = 0;
+                erase_bytes(tty, nBytesToErase);
+                insert_byte = false;
+            }
+            if (buf8[i] == tty->termios.cc[VKILL] && (tty->termios.lflag & (ICANON|ECHOK)))
+            {
+                size_t nBytesToErase = tty->input_buffer.out_ptr - strrfind(tty->input_buffer.buf, '\n') - 1;
+                erase_bytes(tty, nBytesToErase);
+                insert_byte = false;
+            }
+        }
+        if (!insert_byte)
+            continue;
+        if (tty->termios.lflag & ICANON)
+        {
+            if (tty->termios.lflag & ECHO)
+                tty->interface.write(tty, (char*)&buf8[i], 1);
+            else if (tty->termios.lflag & ECHONL && buf8[i] == '\n')
+                tty->interface.write(tty, "\n", 1);
+            
+        }
+        if (tty->termios.iflag & IGNCR && buf8[i] == '\r')
+            continue;
+        if (tty->termios.iflag & INLCR && buf8[i] == '\n')
+        {
+            tty->input_buffer.buf[tty->input_buffer.out_ptr++ % tty->input_buffer.size] = '\r';
+            continue;
+        }
+        uint8_t mask = tty->termios.iflag & ISTRIP ? 0x7f : 0xff;
+        tty->input_buffer.buf[tty->input_buffer.out_ptr++ % tty->input_buffer.size] = 
+            (tty->termios.iflag & (IUCLC|IEXTEN|ICANON)) ? 
+                toupper(buf8[i] & mask) : 
+                (buf8[i] & mask);
+    }
+}
+
+obos_status Vfs_RegisterTTY(const tty_interface *i, dirent **onode, bool pty) 
+{
+    pty = !!pty;
+    if (!i || !i->set_data_ready_cb || !i->write)
+        return OBOS_STATUS_INVALID_ARGUMENT;
+    tty *tty = Vfs_Calloc(1, sizeof(struct tty));
+
+    tty->magic = TTY_MAGIC;
+
+    tty->interface = *i;
+
+    // Initialize the input ring buffer.
+    tty->input_buffer.size = 4096;
+    tty->input_buffer.buf = Vfs_Malloc(tty->input_buffer.size);
+    tty->input_buffer.in_ptr = 0;
+    tty->input_buffer.out_ptr = 0;
+
+    memcpy(tty->termios.cc, default_control, sizeof(default_control));
+    tty->termios.lflag = ICANON|ECHO|ECHOE|IEXTEN|ISIG;
+    tty->termios.oflag = 0;
+    tty->termios.iflag = 0;
+
+    vnode *vn = Drv_AllocateVNode(&OBOS_TTYDriver, (dev_desc)tty, 0, nullptr,
+                                    VNODE_TYPE_CHR);
+    vn->flags |= VFLAGS_IS_TTY;
+    vn->data = tty;
+    size_t index = pty ? last_pty_index++ : last_tty_index++;
+    size_t szName = snprintf(nullptr, 0, "tty%ld", index);
+    char *name = nullptr;
+    snprintf((name = Vfs_Malloc(szName + 1)), szName + 1, "tty%ld", index);
+    OBOS_Log("%s: Registering TTY %s\n", __func__, name);
+    dirent *node = Drv_RegisterVNode(vn, name);
+    Vfs_Free(name);
+
+    tty->ent = node;
+    tty->vn = vn;
+    if (onode)
+        *onode = node;
+
+    i->set_data_ready_cb(tty, data_ready);
+
+    return OBOS_STATUS_SUCCESS;
+}
+
+struct screen_tty {
+    fd keyboard;
+    text_renderer_state* out;
+    void(*data_ready)(void* tty, const void* buf, size_t nBytesReady);
+    thread* data_ready_thread;
+    tty* tty;
+};
+
+static char number_to_secondary(enum scancode code)
+{
+    char ch = 0;
+    switch (code) {
+        case SCANCODE_0:
+            ch = ')';
+            break;
+        case SCANCODE_1:
+            ch = '!';
+            break;
+        case SCANCODE_2:
+            ch = '@';
+            break;
+        case SCANCODE_3:
+            ch = '#';
+            break;
+        case SCANCODE_4:
+            ch = '$';
+            break;
+        case SCANCODE_5:
+            ch = '%';
+            break;
+        case SCANCODE_6:
+            ch = '^';
+            break;
+        case SCANCODE_7:
+            ch = '&';
+            break;
+        case SCANCODE_8:
+            ch = '*';
+            break;
+        case SCANCODE_9:
+            ch = '(';
+            break;
+        default: break;
+    }
+    return ch;
+}
+
+static void poll_keyboard(struct screen_tty* data)
+{
+    while (1)
+    {
+        size_t nReady = 0;
+        Vfs_FdIoctl(&data->keyboard, 1 /* query bytes ready */, &nReady);
+        if (!nReady)
+        {
+            Core_Yield();
+            continue;
+        }
+        char* buffer = Vfs_Malloc(nReady);
+        // size_t bufSize = nReady;
+        keycode *keycode_buffer = Vfs_Calloc(nReady, sizeof(keycode));
+        Vfs_FdRead(&data->keyboard, keycode_buffer, nReady*2, nullptr);
+        for (size_t i = 0; i < nReady;)
+        {
+            keycode code = keycode_buffer[i];
+            enum scancode scancode = SCANCODE_FROM_KEYCODE(code);
+            enum modifiers mod = MODIFIERS_FROM_KEYCODE(code);
+            if (mod & KEY_RELEASED)
+            {
+                nReady--;
+                continue;
+            }
+            if (scancode < SCANCODE_Z)
+                buffer[i++] = (mod & CTRL) ? scancode : ((((mod & CAPS_LOCK) || (mod & SHIFT)) ? 'A' : 'a') + (scancode-SCANCODE_A));
+            else
+            {
+                switch (scancode)
+                {
+                    case SCANCODE_0 ... SCANCODE_9:
+                        if (mod & SHIFT)
+                            buffer[i] = number_to_secondary(scancode);
+                        else
+                            buffer[i] = '0' + (scancode-SCANCODE_0);
+                        break;
+                    case SCANCODE_FORWARD_SLASH:
+                        buffer[i] = (mod & NUMPAD) ? '/' : ((mod & SHIFT) ? '?' : '/');
+                        break;
+                    case SCANCODE_PLUS:
+                        buffer[i] = '+';
+                        break;
+                    case SCANCODE_STAR:
+                        buffer[i] = '*';
+                        break;
+                    case SCANCODE_ENTER:
+                        buffer[i] = '\n';
+                        break;
+                    case SCANCODE_TAB:
+                        buffer[i] = '\t';
+                        break;
+                    case SCANCODE_DOT:
+                        buffer[i] = (mod & NUMPAD) ? '.' : ((~mod & SHIFT) ? '.' : '>');
+                        break;
+                    case SCANCODE_SQUARE_BRACKET_LEFT:
+                        buffer[i] = (~mod & SHIFT) ? '[' : '{';
+                        break;
+                    case SCANCODE_SQUARE_BRACKET_RIGHT:
+                        buffer[i] = (~mod & SHIFT) ? ']' : '}';
+                        break;
+                    case SCANCODE_SEMICOLON:
+                        buffer[i] = (~mod & SHIFT) ? ';' : ':';
+                        break;
+                    case SCANCODE_COMMA:
+                        buffer[i] = (~mod & SHIFT) ? ',' : '<';
+                        break;
+                    case SCANCODE_APOSTROPHE:
+                        buffer[i] = (~mod & SHIFT) ? '\'' : '\"';
+                        break;
+                    case SCANCODE_BACKTICK:
+                        buffer[i] = (~mod & SHIFT) ? '`' : '~';
+                        break;
+                    case SCANCODE_UNDERSCORE:
+                        buffer[i] = (~mod & SHIFT) ? '_' : '-';
+                        break;
+                    case SCANCODE_BACKSLASH:
+                        buffer[i] = (~mod & SHIFT) ? '\\' : '|';
+                        break;
+                    case SCANCODE_SPACE:
+                        buffer[i] = ' ';
+                        break;
+                    case SCANCODE_EQUAL:
+                        buffer[i] = (mod & SHIFT) ? '+' : '=';
+                        break;
+                    case SCANCODE_DASH:
+                        buffer[i] = (mod & SHIFT) ? '_' :  '-';
+                        break;
+                    case SCANCODE_BACKSPACE:
+                        buffer[i] = '\177';
+                        break;
+                    {
+                    char ch = '\0';
+                    case SCANCODE_DOWN_ARROW:
+                        ch = 'B';
+                        goto down;
+                    case SCANCODE_UP_ARROW:
+                        ch = 'A';
+                        goto down;
+                    case SCANCODE_RIGHT_ARROW:
+                        ch = 'C';
+                        goto down;
+                    case SCANCODE_LEFT_ARROW:
+                        ch = 'D';
+                        
+                        down:
+                        nReady += 3;
+                        char buf[4] = {"\x1f[\0"};
+                        buf[3] = ch;
+                        buffer = Vfs_Realloc(buffer, nReady);
+                        buffer[i++] = buf[0];
+                        buffer[i++] = buf[1];
+                        buffer[i++] = buf[2];
+                        buffer[i] = buf[3];
+                        break;
+
+                    }
+                    default:
+                        i--;
+                        nReady--;
+                        break;
+                }
+                i++;
+            }
+        }
+        Vfs_Free(keycode_buffer);
+        if (nReady)
+            data->data_ready(data->tty, buffer, nReady);
+        Vfs_Free(buffer);
+    }
+}
+
+static void screen_set_data_ready_cb(void* tty_, void(*cb)(void* tty, const void* buf, size_t nBytesReady))
+{
+    tty* tty = tty_;
+    struct screen_tty *data = tty->interface.userdata;
+    data->data_ready = cb;
+    data->tty = tty;
+    if (!data->data_ready_thread)
+    {
+        data->data_ready_thread = CoreH_ThreadAllocate(nullptr);
+        thread_ctx ctx = {};
+        void* stack = Mm_VirtualMemoryAlloc(&Mm_KernelContext, nullptr, 0x4000, 0, VMA_FLAGS_KERNEL_STACK, nullptr, nullptr);
+        CoreS_SetupThreadContext(&ctx, (uintptr_t)poll_keyboard, (uintptr_t)data, false, stack, 0x4000);
+        CoreH_ThreadInitialize(data->data_ready_thread, THREAD_PRIORITY_HIGH, Core_DefaultThreadAffinity, &ctx);
+        CoreH_ThreadReady(data->data_ready_thread);
+        Core_ProcessAppendThread(OBOS_KernelProcess, data->data_ready_thread);
+    }
+}
+
+static obos_status screen_write(void* tty_, const char* buf, size_t szBuf)
+{
+    tty* tty = tty_;
+    struct screen_tty *data = tty->interface.userdata;
+    for (size_t i = 0; i < szBuf; i++)
+        OBOS_WriteCharacter(data->out, buf[i]);
+    OBOS_FlushBuffers(data->out);
+    return OBOS_STATUS_SUCCESS;
+}
+
+obos_status VfsH_MakeScreenTTY(tty_interface* i, vnode* keyboard, text_renderer_state* conout)
+{
+    struct screen_tty* screen = Vfs_Calloc(1, sizeof(*screen));
+    obos_status status = Vfs_FdOpenVnode(&screen->keyboard, keyboard, FD_OFLAGS_READ|FD_OFLAGS_UNCACHED);
+    if (obos_is_error(status))
+        return status;
+    screen->out = conout;
+    i->write = screen_write;
+    i->set_data_ready_cb = screen_set_data_ready_cb;
+    i->userdata = screen;
+    return status;
+}

--- a/src/oboskrnl/vfs/tty.h
+++ b/src/oboskrnl/vfs/tty.h
@@ -1,0 +1,123 @@
+/*
+ * oboskrnl/vfs/tty.h
+ *
+ * Copyright (c) 2025 Omar Berrow
+*/
+
+#pragma once
+
+#include <int.h>
+#include <text.h>
+#include <error.h>
+
+#include <vfs/keycode.h>
+#include <vfs/vnode.h>
+#include <vfs/dirent.h>
+
+// Raw TTY I/O commands
+typedef struct tty_interface {
+    void *userdata;
+    // 'buf' is assumed to be 8 bytes.
+    // if !block and there is no data to be read, return OBOS_STATUS_WOULD_BLOCK, and set *nRead to zero.
+    // void* tty is a struct tty *tty
+    void(*set_data_ready_cb)(void* tty, void(*cb)(void* tty, const void* buf, size_t nBytesReady));
+    obos_status(*write)(void* tty, const char* buf, size_t szBuf);
+} tty_interface;
+
+#define VINTR    0
+#define VQUIT    1
+#define VERASE   2
+#define VKILL    3
+#define VEOF     4
+#define VTIME    5
+#define VMIN     6
+#define VSWTC    7
+#define VSTART   8
+#define VSTOP    9
+#define VSUSP    10
+#define VEOL     11
+#define VREPRINT 12
+#define VDISCARD 13
+#define VWERASE  14
+#define VLNEXT   15
+#define VEOL2    16
+
+// lflag
+#define ISIG 0000001
+#define ICANON 0000002
+#define ECHO 0000010
+#define ECHOE 0000020
+#define ECHOK 0000040
+#define ECHONL 0000100
+#define NOFLSH 0000200
+#define TOSTOP 0000400
+#define IEXTEN 0100000
+
+// oflag
+#define OPOST 0000001
+#define OLCUC 0000002
+#define ONLCR 0000004
+#define OCRNL 0000010
+#define ONOCR 0000020
+#define ONLRET 0000040
+#define OFILL 0000100
+#define OFDEL 0000200
+
+// iflag
+#define IGNBRK 0000001
+#define BRKINT 0000002
+#define IGNPAR 0000004
+#define PARMRK 0000010
+#define INPCK 0000020
+#define ISTRIP 0000040
+#define INLCR 0000100
+#define IGNCR 0000200
+#define ICRNL 0000400
+#define IUCLC 0001000
+#define IXON 0002000
+#define IXANY 0004000
+#define IXOFF 0010000
+#define IMAXBEL 0020000
+#define IUTF8 0040000
+
+struct termios
+{
+    uint32_t iflag;
+    uint32_t oflag;
+    uint32_t cflag;
+    uint32_t lflag;
+    uint8_t line;
+    uint8_t cc[32];
+    // for linux compatibilty, ignored.
+    uint32_t ibaud;
+    // same here
+    uint32_t obaud;
+};
+
+typedef struct tty {
+#define TTY_MAGIC 0x63EA62F4
+    uint32_t magic;
+    tty_interface interface;
+    vnode* vn;
+    dirent* ent;
+    struct termios termios;
+    struct {
+        char* buf;
+        size_t out_ptr;
+        size_t in_ptr;
+        size_t size;
+    } input_buffer;
+    struct process* fg_job;
+    bool quoted : 1;
+} tty;
+
+#define TTY_IOCTL_SETATTR 0x01
+#define TTY_IOCTL_GETATTR 0x02
+#define TTY_IOCTL_FLOW 0x03
+#define TTY_IOCTL_FLUSH 0x04
+#define TTY_IOCTL_DRAIN 0x05
+
+// Makes a copy of 'i' before creating the TTY.
+obos_status Vfs_RegisterTTY(const tty_interface* i, dirent** node, bool pty);
+
+obos_status VfsH_MakeScreenTTY(tty_interface* i, vnode* keyboard, text_renderer_state* conout);


### PR DESCRIPTION
Adds TTY support and fixes bugs with signals.
Closes #35 
Breaks bash, since sys_pselect can no longer assume there is always an event, and read() will just wait for a byte.