### PR TITLE
vfs: add proper tmpfs

### DIFF
--- a/src/drivers/generic/ahci/main.c
+++ b/src/drivers/generic/ahci/main.c
@@ -85,7 +85,7 @@ void driver_cleanup_callback()
         Port* port = &Ports[i];
         if (!port->vn)
             continue;
-        Vfs_UnlinkNode(port->ent);
+        Vfs_UnlinkNode(port->ent, false);
         port->vn->flags |= VFLAGS_DRIVER_DEAD; 
     }
 }

--- a/src/drivers/generic/extfs/interface.c
+++ b/src/drivers/generic/extfs/interface.c
@@ -290,6 +290,59 @@ obos_status list_dir(dev_desc dir, void* vn, iterate_decision(*cb)(dev_desc desc
     return OBOS_STATUS_SUCCESS;
 }
 
+obos_status get_file_perms(dev_desc desc, driver_file_perm *perm)
+{
+    ext_inode_handle* hnd = (void*)desc;
+    if (!hnd || !perm)
+        return OBOS_STATUS_INVALID_ARGUMENT;
+    if (desc == UINTPTR_MAX)
+        return OBOS_STATUS_INVALID_ARGUMENT;
+    ext_inode* node = ext_read_inode(hnd->cache, hnd->ino);
+    if (!node)
+        return OBOS_STATUS_INVALID_ARGUMENT; // uh oh :D
+    perm->mode = node->mode & 0777;
+    Free(EXT_Allocator, node, sizeof(*node));
+    return OBOS_STATUS_SUCCESS;
+}
+
+obos_status get_file_type(dev_desc desc, file_type *type)
+{
+    ext_inode_handle* hnd = (void*)desc;
+    if (!hnd || !type)
+        return OBOS_STATUS_INVALID_ARGUMENT;
+    if (desc == UINTPTR_MAX)
+        return OBOS_STATUS_INVALID_ARGUMENT;
+    ext_inode* node = ext_read_inode(hnd->cache, hnd->ino);
+    if (!node)
+        return OBOS_STATUS_INVALID_ARGUMENT; // uh oh :D
+    if (ext_ino_test_type(node, EXT2_S_IFDIR))      *type = FILE_TYPE_DIRECTORY;
+    else if (ext_ino_test_type(node, EXT2_S_IFREG)) *type = FILE_TYPE_REGULAR_FILE;
+    else if (ext_ino_test_type(node, EXT2_S_IFLNK)) *type = FILE_TYPE_SYMBOLIC_LINK;
+    else
+    {
+        Free(EXT_Allocator, node, sizeof(*node));
+        return OBOS_STATUS_INVALID_ARGUMENT;
+    }
+    Free(EXT_Allocator, node, sizeof(*node));
+    return OBOS_STATUS_SUCCESS;
+}
+
+obos_status get_file_owner(dev_desc desc, uid* uid, gid* gid)
+{
+    ext_inode_handle* hnd = (void*)desc;
+    if (!hnd)
+        return OBOS_STATUS_INVALID_ARGUMENT;
+    if (desc == UINTPTR_MAX)
+        return OBOS_STATUS_INVALID_ARGUMENT;
+    ext_inode* node = ext_read_inode(hnd->cache, hnd->ino);
+    if (!node)
+        return OBOS_STATUS_INVALID_ARGUMENT; // uh oh :D
+    if (uid) *uid = le16_to_host(node->uid);
+    if (gid) *gid = le16_to_host(node->gid);
+    Free(EXT_Allocator, node, sizeof(*node));
+    return OBOS_STATUS_SUCCESS;
+}
+
 static size_t str_search(const char* str, char ch)
 {
     size_t ret = strchr(str, ch);

--- a/src/drivers/generic/extfs/main.c
+++ b/src/drivers/generic/extfs/main.c
@@ -100,6 +100,7 @@ OBOS_WEAK obos_status premove_file(void* vn, const char* path);
 OBOS_WEAK obos_status trunc_file(dev_desc desc, size_t newsize);
 OBOS_WEAK obos_status set_file_perms(dev_desc desc, driver_file_perm newperm);
 OBOS_WEAK obos_status set_file_owner(dev_desc desc, uid owner_uid, gid group_uid);
+OBOS_WEAK obos_status get_file_owner(dev_desc desc, uid* uid, gid* gid);
 OBOS_WEAK obos_status get_file_perms(dev_desc desc, driver_file_perm *perm);
 OBOS_WEAK obos_status get_file_type(dev_desc desc, file_type *type);
 OBOS_WEAK obos_status list_dir(dev_desc dir, void* vn, iterate_decision(*cb)(dev_desc desc, size_t blkSize, size_t blkCount, void* userdata, const char* name), void* userdata);
@@ -145,6 +146,7 @@ __attribute__((section(OBOS_DRIVER_HEADER_SECTION))) driver_header drv_hdr = {
         .get_file_perms = get_file_perms,
         .set_file_perms = set_file_perms,
         .set_file_owner = set_file_owner,
+        .get_file_owner = get_file_owner,
         .get_file_type = get_file_type,
         .get_file_inode = get_file_inode,
         .list_dir = list_dir,

--- a/src/drivers/generic/initrd/main.c
+++ b/src/drivers/generic/initrd/main.c
@@ -104,6 +104,37 @@ obos_status vnode_search(void** vn_found, dev_desc desc, void* dev_vn)
     initrd_inode* ino = (void*)desc;
     if (!ino)
         return OBOS_STATUS_INVALID_ARGUMENT;
+    if (ino->dead)
+        return OBOS_STATUS_INVALID_ARGUMENT; // confusing...
+    if (!ino->vnode)
+    {
+        ino->vnode = Vfs_Calloc(1, sizeof(vnode));
+        ino->vnode->desc = (uintptr_t)ino;
+        ino->vnode->filesize = ino->filesize;
+        ino->vnode->blkSize = 1;
+        ino->vnode->uid = 0;
+        ino->vnode->gid = 0;
+        ino->vnode->inode = ino->ino;
+        ino->vnode->perm = ino->perm;
+        if (ino->hdr)
+            ino->vnode->times.change = oct2bin(ino->hdr->last_mod, strnlen(ino->hdr->last_mod, 12));
+        ino->vnode->times.birth = ino->vnode->times.change;
+        ino->vnode->times.access = ino->vnode->times.change;
+        switch (ino->type) {
+            case FILE_TYPE_REGULAR_FILE:
+                ino->vnode->vtype = VNODE_TYPE_REG;
+                break;
+            case FILE_TYPE_DIRECTORY:
+                ino->vnode->vtype = VNODE_TYPE_DIR;
+                break;
+            case FILE_TYPE_SYMBOLIC_LINK:
+                ino->vnode->vtype = VNODE_TYPE_LNK;
+                ino->vnode->un.linked = ino->linked_path;
+                break;
+            default:
+                OBOS_UNREACHABLE;
+        }
+    }
     *vn_found = ino->vnode;
     return OBOS_STATUS_SUCCESS;
 }

--- a/src/drivers/generic/initrd/main.c
+++ b/src/drivers/generic/initrd/main.c
@@ -53,32 +53,24 @@ OBOS_PAGEABLE_FUNCTION obos_status ioctl(dev_desc what, uint32_t request, void* 
 void driver_cleanup_callback()
 {}
 
-obos_status symlink_set_path(dev_desc desc, const char* to) { OBOS_UNUSED(desc && to); return OBOS_STATUS_SUCCESS; }
-
+OBOS_WEAK obos_status symlink_set_path(dev_desc desc, const char* to);
 OBOS_WEAK obos_status query_path(dev_desc desc, const char** path);
 OBOS_WEAK obos_status path_search(dev_desc* found, void*, const char* what, dev_desc parent);
 OBOS_WEAK obos_status get_linked_path(dev_desc desc, const char** found);
 OBOS_WEAK obos_status move_desc_to(dev_desc desc, dev_desc new_parent, const char* name);
 OBOS_WEAK obos_status mk_file(dev_desc* newDesc, dev_desc parent, void* vn, const char* name, file_type type, driver_file_perm perm);
 OBOS_WEAK obos_status remove_file(dev_desc desc);
-obos_status set_file_perms(dev_desc desc, driver_file_perm newperm)
-{
-    OBOS_UNUSED(desc);
-    OBOS_UNUSED(newperm);
-    return OBOS_STATUS_SUCCESS;
-}
+OBOS_WEAK obos_status set_file_perms(dev_desc desc, driver_file_perm newperm);
 OBOS_WEAK obos_status get_file_perms(dev_desc desc, driver_file_perm *perm);
-obos_status set_file_owner(dev_desc desc, uid owner_uid, gid group_uid)
-{
-    OBOS_UNUSED(desc && owner_uid && group_uid);
-    return OBOS_STATUS_SUCCESS;
-}
+OBOS_WEAK obos_status set_file_owner(dev_desc desc, uid owner_uid, gid group_uid);
 OBOS_WEAK obos_status get_file_type(dev_desc desc, file_type *type);
 OBOS_WEAK obos_status list_dir(dev_desc dir, void* unused, iterate_decision(*cb)(dev_desc desc, size_t blkSize, size_t blkCount, void* userdata, const char* name), void* userdata);
 OBOS_WEAK obos_status stat_fs_info(void *vn, drv_fs_info *info);
 
-dev_desc irp_process_dryop(irp* req)
+obos_status irp_process_dryop(irp* req)
 {
+    if (req->op == IRP_WRITE) return OBOS_STATUS_READ_ONLY;
+
     dev_desc desc = req->desc;
     size_t blkCount = req->blkCount;
     size_t blkOffset = req->blkOffset;
@@ -149,7 +141,7 @@ OBOS_WEAK obos_status submit_irp(void* /* irp* */ request_)
     else
         request->status = request->op == IRP_READ ? 
             read_sync(request->desc, request->buff, request->blkCount, request->blkOffset, &request->nBlkRead) :
-            write_sync(request->desc, request->cbuff, request->blkCount, request->blkOffset, &request->nBlkRead);
+            OBOS_STATUS_READ_ONLY;
     request->evnt = nullptr;
     return OBOS_STATUS_SUCCESS;
 }
@@ -325,6 +317,7 @@ initrd_inode* create_inode_boot(const ustar_hdr* hdr)
 
     return ino;
 }
+
 driver_init_status OBOS_DriverEntry(driver_id* this)
 {
     (void)this;
@@ -442,90 +435,6 @@ OBOS_PAGEABLE_FUNCTION obos_status get_linked_path(dev_desc desc, const char** f
     return OBOS_STATUS_SUCCESS;
 }
 
-obos_status trunc_file(dev_desc desc, size_t newsize /* note, newsize must be less than the filesize */)
-{
-    initrd_inode* inode = (void*)desc;
-    if (!inode)
-        return OBOS_STATUS_INVALID_ARGUMENT;
-
-    OBOS_ASSERT(inode->filesize >= newsize);
-    if (inode->filesize < newsize)
-        return OBOS_STATUS_INVALID_ARGUMENT;
-    if (inode->filesize == newsize)
-        return OBOS_STATUS_SUCCESS;
-
-    size_t oldsize = inode->filesize;
-    inode->filesize = newsize;
-    if (inode->persistent)
-    {
-        char* new_data = Allocate(OBOS_NonPagedPoolAllocator, inode->filesize, nullptr);
-        memcpy(new_data, inode->data, inode->filesize);
-        inode->data = new_data;
-        inode->persistent = false;
-    }
-    else
-        inode->data = Reallocate(OBOS_NonPagedPoolAllocator, inode->data, inode->filesize, oldsize, nullptr);
-
-    return OBOS_STATUS_SUCCESS;
-}
-
-obos_status move_desc_to(dev_desc desc, dev_desc dnew_parent, const char* name)
-{
-    initrd_inode* ino = (void*)desc;
-    initrd_inode* new_parent = (void*)dnew_parent;
-    if (dnew_parent == UINTPTR_MAX)
-        new_parent = InitrdRoot;
-    
-    if (!ino) return OBOS_STATUS_INVALID_ARGUMENT;
-
-    // FIXME: This does not handle persistent inodes.
-    // This is problematic because if the old name is accessed,
-    // then it will be recreated.
-    if (new_parent)
-    {
-        if (ino->next)
-            ino->next->prev = ino->prev;
-        if (ino->prev)
-            ino->prev->next = ino->next;
-        if (ino->parent->children.head)
-            ino->parent->children.head = ino->next;
-        if (ino->parent->children.tail)
-            ino->parent->children.tail = ino->prev;
-        ino->parent->children.nChildren--;
-        ino->parent = new_parent;
-        if (!ino->parent->children.head)
-            ino->parent->children.head = ino;
-        if (ino->parent->children.tail)
-            ino->parent->children.tail->next = ino;
-        ino->prev = ino->parent->children.tail;
-        ino->parent->children.tail = ino;
-        ino->parent->children.nChildren++;
-    }
-    if (name)
-    {
-        ino->name_len = 0;
-        Free(OBOS_KernelAllocator, ino->name, ino->name_size);
-        ino->name_size = ino->name_len = strlen(name) + 1;
-        ino->name_size++;
-        ino->name = memcpy(Allocate(OBOS_KernelAllocator, ino->name_size, nullptr), name, ino->name_len);
-        
-        ino->path_len = 0;
-        Free(OBOS_KernelAllocator, ino->path, ino->path_size);
-        ino->path_len = snprintf(nullptr, 0, "%.*s%c%s", 
-            ino->parent->path_len, ino->parent->path,
-            (ino->parent->path[ino->parent->path_len-1] == '/' ? '\0' : '/'),
-            ino->name);
-        ino->path_size = ino->path_len + 1;
-        ino->path = Allocate(OBOS_KernelAllocator, ino->path_size, nullptr);
-        snprintf(ino->path, ino->path_size, "%.*s%c%s", 
-            ino->parent->path_len, ino->parent->path,
-            (ino->parent->path[ino->parent->path_len-1] == '/' ? '\0' : '/'),
-            ino->name);
-    }
-
-    return OBOS_STATUS_SUCCESS;
-}
-
 static char* fullpath(dev_desc parent, const char* what)
 {
     char *ret = nullptr;
@@ -546,6 +455,7 @@ static char* fullpath(dev_desc parent, const char* what)
     OBOS_ENSURE(ret);
     return ret;
 }
+
 initrd_inode* create_inode_with_parents(const char* path, const ustar_hdr* hdr)
 {
     if (!hdr)
@@ -628,6 +538,7 @@ initrd_inode* create_inode_with_parents(const char* path, const ustar_hdr* hdr)
 
     return ino;
 }
+
 OBOS_PAGEABLE_FUNCTION obos_status path_search(dev_desc* found, void* unused, const char* what, dev_desc parent)
 {
     OBOS_UNUSED(unused);
@@ -744,134 +655,38 @@ OBOS_PAGEABLE_FUNCTION obos_status list_dir(dev_desc dir_, void* unused, iterate
     return OBOS_STATUS_SUCCESS;
 }
 
-// static iterate_decision cb(dev_desc desc, size_t blkSize, size_t blkCount, void* userdata, const char* name)
-// {
-//     OBOS_UNUSED(blkSize);
-//     OBOS_UNUSED(blkCount);
-//     OBOS_UNUSED(name);
+static iterate_decision cb(dev_desc desc, size_t blkSize, size_t blkCount, void* userdata, const char* name)
+{
+    OBOS_UNUSED(blkSize);
+    OBOS_UNUSED(blkCount);
+    OBOS_UNUSED(name);
 
-//     size_t* const fileCount = userdata;
-//     (*fileCount)++;
+    size_t* const fileCount = userdata;
+    (*fileCount)++;
 
-//     initrd_inode* ino = (void*)desc;
-//     if (ino->type == FILE_TYPE_DIRECTORY)
-//         list_dir(desc, nullptr, cb, userdata);
-//     return ITERATE_DECISION_CONTINUE;
-// }
+    initrd_inode* ino = (void*)desc;
+    if (ino->type == FILE_TYPE_DIRECTORY)
+        list_dir(desc, nullptr, cb, userdata);
+    return ITERATE_DECISION_CONTINUE;
+}
 
 obos_status stat_fs_info(void *vn, drv_fs_info *info)
 {
     OBOS_UNUSED(vn);
-    static size_t fileCount = 0;
-    // if (fileCount == SIZE_MAX)
-    // {
-    //     fileCount = 0;
-    //     list_dir(UINTPTR_MAX, vn, cb, &fileCount);
-    // }
+    static size_t fileCount = SIZE_MAX;
+    if (fileCount == SIZE_MAX)
+    {
+        fileCount = 0;
+        list_dir(UINTPTR_MAX, vn, cb, &fileCount);
+    }
     info->partBlockSize = 1;
     info->fsBlockSize = 1;
     info->availableFiles = SIZE_MAX;
     info->fileCount = fileCount;
     info->szFs = (Mm_TotalPhysicalPages - Mm_TotalPhysicalPagesUsed) * OBOS_PAGE_SIZE;
     info->freeBlocks = info->szFs;
-    info->flags = 0;
+    info->flags = FS_FLAGS_RDONLY;
     // TODO: Is there a proper value for this?
     info->nameMax = 100;
-    return OBOS_STATUS_SUCCESS;
-}
-
-obos_status mk_file(dev_desc* newDesc, dev_desc parent_desc, void* vn, const char* name, file_type type, driver_file_perm perm)
-{
-    OBOS_UNUSED(vn);
-    initrd_inode *parent = (initrd_inode*)parent_desc;
-    if (parent_desc == UINTPTR_MAX)
-        parent = InitrdRoot;
-    if (!parent_desc || !newDesc || !name)
-        return OBOS_STATUS_INVALID_ARGUMENT;
-
-    initrd_inode *new = ZeroAllocate(OBOS_KernelAllocator, 1, sizeof(initrd_inode), nullptr);
-    new->name_size = new->name_len = strlen(name);
-    new->name_size++;
-    new->type = type;
-    new->perm = perm;
-    new->ino = CurrentInodeNumber++;
-    new->name = Allocate(OBOS_KernelAllocator, new->name_len+1, nullptr);
-    memcpy(new->name, name, new->name_len);
-    new->name[new->name_len] = 0;
-    new->path_len = parent->path_len + 1 + new->name_len;
-    new->path_size = new->path_len + 1;
-    new->path = Allocate(OBOS_KernelAllocator, new->path_len+1, nullptr);
-    memcpy(new->path, parent->path, parent->path_len);
-    new->path[parent->path_len] = '/';
-    memcpy(&new->path[parent->path_len+1], new->name, new->name_len);
-    new->path[new->path_len] = 0;
-    // printf("created new node: parent.path: %s, new.path: %s, new.name: %s\n", parent->path, new->path, new->name);
-
-    new->parent = parent;
-    if (!parent->children.head)
-        parent->children.head = new;
-    if (parent->children.tail)
-        parent->children.tail->next = new;
-    new->prev = parent->children.tail;
-    parent->children.tail = new;
-    parent->children.nChildren++;
-
-    *newDesc = (dev_desc)new;
-    return OBOS_STATUS_SUCCESS;
-}
-
-obos_status write_sync(dev_desc desc, const void* buf, size_t blkCount, size_t blkOffset, size_t* nBlkWritten)
-{
-    initrd_inode* inode = (void*)desc;
-    if (!inode || !buf)
-        return OBOS_STATUS_INVALID_ARGUMENT;
-    if (!blkCount)
-        return OBOS_STATUS_SUCCESS;
-    if (inode->type != FILE_TYPE_REGULAR_FILE)
-        return OBOS_STATUS_NOT_A_FILE;
-    size_t nToExpand = ((blkOffset + blkCount) > inode->filesize) ? (blkOffset + blkCount) - inode->filesize : 0;
-    inode->filesize += nToExpand;
-    if (inode->persistent)
-    {
-        char* new_data = Allocate(OBOS_NonPagedPoolAllocator, inode->filesize, nullptr);
-        memcpy(new_data, inode->data, inode->filesize);
-        inode->data = new_data;
-        inode->persistent = false;
-    }
-    else
-        inode->data = Reallocate(OBOS_NonPagedPoolAllocator, inode->data, inode->filesize, inode->filesize-nToExpand, nullptr);
-    memcpy(inode->data+blkOffset, buf, blkCount);
-    if (nBlkWritten)
-        *nBlkWritten = blkCount;
-    return OBOS_STATUS_SUCCESS;
-}
-
-obos_status remove_file(dev_desc desc)
-{
-    initrd_inode* inode = (void*)desc;
-    if (!inode)
-        return OBOS_STATUS_INVALID_ARGUMENT;
-    if (inode->parent)
-    {
-        if (!inode->persistent)
-        {
-            if (inode->next)
-                inode->next->prev = inode->prev;
-            if (inode->prev)
-                inode->prev->next = inode->next;
-            if (!inode->prev)
-                inode->parent->children.head = inode->next;
-            if (!inode->next)
-                inode->parent->children.tail = inode->prev;
-            inode->parent->children.nChildren--;
-        }
-        else
-            inode->dead = true;
-    }
-    if (!inode->persistent)
-    {
-        Free(OBOS_NonPagedPoolAllocator, inode->data, inode->filesize);
-        Free(OBOS_KernelAllocator, inode, sizeof(*inode));
-    }
     return OBOS_STATUS_SUCCESS;
 }

--- a/src/drivers/generic/libps2/main.c
+++ b/src/drivers/generic/libps2/main.c
@@ -148,7 +148,7 @@ obos_status ioctl_argp_size(uint32_t request, size_t* res)
 
 static void cleanup_port_vn(ps2_port* port)
 {
-    Vfs_UnlinkNode(port->ent);
+    Vfs_UnlinkNode(port->ent, false);
     port->vn->flags |= VFLAGS_DRIVER_DEAD;
 }
 

--- a/src/oboskrnl/CMakeLists.txt
+++ b/src/oboskrnl/CMakeLists.txt
@@ -23,7 +23,7 @@ list (APPEND oboskrnl_sources
 	"net/ip.c" "net/arp.c" "power/event.c" "net/udp.c"
 	"net/icmp.c" "net/tcp.c" "vfs/socket.c" "net/lo.c"
 	"kinit.c" "vfs/local_socket.c" "perm.c" "contrib/tjec.c"
-	"contrib/csprng.c" "vfs/pty.c"
+	"contrib/csprng.c" "vfs/pty.c" "vfs/tmpfs.c"
 )
 
 add_executable(oboskrnl)

--- a/src/oboskrnl/arch/m68k/syscall.c
+++ b/src/oboskrnl/arch/m68k/syscall.c
@@ -173,6 +173,8 @@ const char *syscall_to_string[] = {
     "Sys_SetSid",
     "Sys_GetSid",
     "Sys_Chroot",
+    "Sys_OpenTmpFS",
+    "Sys_Mount2",
 };
 
 const char* status_to_string[] = {

--- a/src/oboskrnl/arch/x86_64/syscall.c
+++ b/src/oboskrnl/arch/x86_64/syscall.c
@@ -269,6 +269,8 @@ const char* syscall_to_string[] = {
     "Sys_SetSid",
     "Sys_GetSid",
     "Sys_Chroot",
+    "Sys_OpenTmpFS",
+    "Sys_Mount2",
 };
 
 const char* status_to_string[] = {

--- a/src/oboskrnl/driver_interface/header.h
+++ b/src/oboskrnl/driver_interface/header.h
@@ -206,13 +206,15 @@ typedef struct driver_ftable
     obos_status(*symlink_set_path)(dev_desc desc, const char* to);
 
     // times is of type 'struct file_times' defined in vfs/vnode.h
-    obos_status(*set_file_times)(dev_desc desc, void* times);
     obos_status(*get_file_perms)(dev_desc desc, driver_file_perm *perm);
+    obos_status(*get_file_owner)(dev_desc desc, uid *owner_uid, gid *group_uid);
+    obos_status(*get_file_type)(dev_desc desc, file_type *type);
+    obos_status(*get_file_inode)(dev_desc desc, uint32_t *ino);
+    
+    obos_status(*set_file_times)(dev_desc desc, void* times);
     obos_status(*set_file_perms)(dev_desc desc, driver_file_perm newperm);
     // if an ID is -1, it means leave that field UNCHANGED
     obos_status(*set_file_owner)(dev_desc desc, uid owner_uid, gid group_uid);
-    obos_status(*get_file_type)(dev_desc desc, file_type *type);
-    obos_status(*get_file_inode)(dev_desc desc, uint32_t *ino);
 
     // If dir is UINTPTR_MAX, it refers to the root directory.
     obos_status(*list_dir)(dev_desc dir, void* vn, iterate_decision(*cb)(dev_desc desc, size_t blkSize, size_t blkCount, void* userdata, const char* name), void* userdata);

--- a/src/oboskrnl/mm/alloc.c
+++ b/src/oboskrnl/mm/alloc.c
@@ -206,7 +206,6 @@ void* Mm_VirtualMemoryAllocEx(context* ctx, void* base_, size_t size, prot_flags
         }
         if (!(file->flags & FD_FLAGS_WRITE) && !(flags & VMA_FLAGS_PRIVATE))
             prot |= OBOS_PROTECTION_READ_ONLY;
-        file->vn->nMappedRegions++;
         if (~prot & OBOS_PROTECTION_READ_ONLY)
             file->vn->nWriteableMappedRegions++;
     }

--- a/src/oboskrnl/mm/handler.c
+++ b/src/oboskrnl/mm/handler.c
@@ -115,6 +115,8 @@ static obos_status ref_page(context* ctx, const page_info *curr)
     if (!ent)
     {
         ent = ZeroAllocate(Mm_Allocator, 1, sizeof(working_set_entry), nullptr);
+        if (!ent)
+            return OBOS_STATUS_NOT_ENOUGH_MEMORY;
         ent->info.virt = curr->virt;
         ent->info.prot = curr->prot;
         ent->info.range = rng;
@@ -122,6 +124,12 @@ static obos_status ref_page(context* ctx, const page_info *curr)
     }
     ent->refs++;
     working_set_node* node = ZeroAllocate(Mm_Allocator, 1, sizeof(working_set_node), nullptr);
+    if (!node)
+    {
+        if (allocated_ent)
+            Free(Mm_Allocator, ent, sizeof(*ent));
+        return OBOS_STATUS_NOT_ENOUGH_MEMORY;
+    }
     node->data = ent;
 #if defined(OBOS_PAGE_REPLACEMENT_AGING)
     status = Mm_AgingReferencePage(ctx, node);

--- a/src/oboskrnl/partition.c
+++ b/src/oboskrnl/partition.c
@@ -33,6 +33,7 @@ void OBOS_PartProbeAllDrives(bool check_checksum)
     // for (volatile bool b = true; b; )
     //     ;
     dirent* directory = Vfs_DevRoot;
+    Vfs_PopulateDirectory(directory);
     for (dirent* ent = directory->d_children.head; ent; )
     {
         if (ent->vnode->vtype == VNODE_TYPE_BLK && !(ent->vnode->flags & VFLAGS_PARTITION))

--- a/src/oboskrnl/syscall.c
+++ b/src/oboskrnl/syscall.c
@@ -521,6 +521,7 @@ uintptr_t OBOS_SyscallTable[] = {
     (uintptr_t)Sys_SetSid,
     (uintptr_t)Sys_GetSid,
     (uintptr_t)Sys_Chroot,
+    (uintptr_t)Sys_OpenTmpFS,
 };
 
 // Arch syscall table is defined per-arch

--- a/src/oboskrnl/syscall.c
+++ b/src/oboskrnl/syscall.c
@@ -522,6 +522,7 @@ uintptr_t OBOS_SyscallTable[] = {
     (uintptr_t)Sys_GetSid,
     (uintptr_t)Sys_Chroot,
     (uintptr_t)Sys_OpenTmpFS,
+    (uintptr_t)Sys_Mount2,
 };
 
 // Arch syscall table is defined per-arch

--- a/src/oboskrnl/vfs/create.c
+++ b/src/oboskrnl/vfs/create.c
@@ -38,7 +38,7 @@ obos_status Vfs_CreateNodeOwner(dirent* parent, const char* name, uint32_t vtype
 {
     if (!parent)
         parent = Vfs_GetRoot();
-    if (!name || !vtype || vtype >= VNODE_TYPE_BAD)
+    if (!name || !(vtype & ~BIT(31)) || (vtype & ~BIT(31)) >= VNODE_TYPE_BAD)
         return OBOS_STATUS_INVALID_ARGUMENT;
 
     obos_status status = Vfs_Access(parent->vnode, 
@@ -67,13 +67,18 @@ obos_status Vfs_CreateNodeOwner(dirent* parent, const char* name, uint32_t vtype
         return OBOS_STATUS_UNIMPLEMENTED;
 
     do {
-        dirent* found = VfsH_DirentLookupFrom(name, parent);
+        dirent* found = nullptr;
+        if (vtype & BIT(31))
+            found = VfsH_DirentLookupFromCacheOnly(name, parent);
+        else
+            found = VfsH_DirentLookupFrom(name, parent);
+
         if (found)
             return OBOS_STATUS_ALREADY_INITIALIZED;
     } while(0);
 
     file_type type = 0;
-    switch (vtype)
+    switch (vtype & ~BIT(31))
     {
         case VNODE_TYPE_REG:
             type = FILE_TYPE_REGULAR_FILE;
@@ -92,11 +97,11 @@ obos_status Vfs_CreateNodeOwner(dirent* parent, const char* name, uint32_t vtype
             return OBOS_STATUS_INVALID_ARGUMENT;
     }
     vnode* vn = Vfs_Calloc(1, sizeof(vnode));
-    vn->gid = Core_GetCurrentThread()->proc->egid;
-    vn->uid = Core_GetCurrentThread()->proc->euid;
+    vn->gid = gid;
+    vn->uid = uid;
     vn->perm = mode;
     vn->flags = 0;
-    vn->vtype = vtype;
+    vn->vtype = vtype & ~BIT(31);
     vn->mount_point = parent_mnt;
     
     long current_time = 0;
@@ -111,42 +116,47 @@ obos_status Vfs_CreateNodeOwner(dirent* parent, const char* name, uint32_t vtype
     dirent* ent = Vfs_Calloc(1, sizeof(dirent));
     OBOS_InitString(&ent->name, name);
     ent->vnode = vn;
-    vnode* mount_vn = parent_mnt->device;
-    status = OBOS_STATUS_SUCCESS;
-    if (parent_mnt->fs_driver->driver->header.flags & DRIVER_HEADER_DIRENT_CB_PATHS)
+
+    if (~vtype & BIT(31))
     {
-        char* parent_path = VfsH_DirentPath(parent, parent_mnt->root);
-        status = ftable->pmk_file(&vn->desc, parent_path, mount_vn, name, type, mode);
-        Vfs_Free(parent_path);
-    }
-    else
-        status = ftable->mk_file(&vn->desc, parent_vn->flags & VFLAGS_MOUNTPOINT ? UINTPTR_MAX : parent_vn->desc, mount_vn, name, type, mode);
-    if (obos_is_error(status))
-    {
-        Vfs_Free(vn);
-        Vfs_Free(ent);
-        return status;
-    }
-    if (ftable->set_file_owner)
-    {
-        status = ftable->set_file_owner(vn->desc, uid, gid);
+        vnode* mount_vn = parent_mnt->device;
+        status = OBOS_STATUS_SUCCESS;
+        if (parent_mnt->fs_driver->driver->header.flags & DRIVER_HEADER_DIRENT_CB_PATHS)
+        {
+            char* parent_path = VfsH_DirentPath(parent, parent_mnt->root);
+            status = ftable->pmk_file(&vn->desc, parent_path, mount_vn, name, type, mode);
+            Vfs_Free(parent_path);
+        }
+        else
+            status = ftable->mk_file(&vn->desc, parent_vn->flags & VFLAGS_MOUNTPOINT ? UINTPTR_MAX : parent_vn->desc, mount_vn, name, type, mode);
         if (obos_is_error(status))
         {
             Vfs_Free(vn);
             Vfs_Free(ent);
             return status;
         }
-    }   
-    Vfs_UpdateFileTime(vn);
-    if (ftable->get_file_inode)
-        ftable->get_file_inode(vn->desc, &vn->inode);
+        if (ftable->set_file_owner)
+        {
+            status = ftable->set_file_owner(vn->desc, uid, gid);
+            if (obos_is_error(status))
+            {
+                Vfs_Free(vn);
+                Vfs_Free(ent);
+                return status;
+            }
+        }
+        Vfs_UpdateFileTime(vn);
+        if (ftable->get_file_inode)
+            ftable->get_file_inode(vn->desc, &vn->inode);
+    }
+    
     VfsH_DirentAppendChild(parent, ent);
     LIST_APPEND(dirent_list, &parent_mnt->dirent_list, ent);
     ent->vnode->refs++;
     return status;
 }
 
-obos_status Vfs_TruncateFile(vnode* vn, size_t new_size)
+obos_status Vfs_TruncateFile(vnode* vn, size_t new_size, bool no_drv)
 {
     if (!vn)
         return OBOS_STATUS_INVALID_ARGUMENT;
@@ -169,7 +179,7 @@ obos_status Vfs_TruncateFile(vnode* vn, size_t new_size)
     // if (!VfsH_LockMountpoint(point))
     //     return OBOS_STATUS_ABORTED;
 
-    obos_status status = header->ftable.trunc_file(vn->desc, new_size);
+    obos_status status = no_drv ? OBOS_STATUS_SUCCESS : header->ftable.trunc_file(vn->desc, new_size);
     if (obos_is_error(status))
         goto failed;
 
@@ -194,7 +204,7 @@ obos_status Vfs_TruncateFile(vnode* vn, size_t new_size)
     return status;
 }
 
-OBOS_EXPORT obos_status Vfs_UnlinkNode(dirent* node)
+OBOS_EXPORT obos_status Vfs_UnlinkNode(dirent* node, bool no_drv)
 {
     if (!node)
         return OBOS_STATUS_SUCCESS;
@@ -224,7 +234,7 @@ OBOS_EXPORT obos_status Vfs_UnlinkNode(dirent* node)
 
     status = OBOS_STATUS_SUCCESS;
 
-    if (node->vnode->vtype == VNODE_TYPE_DIR || node->vnode->vtype == VNODE_TYPE_REG || node->vnode->vtype == VNODE_TYPE_LNK)
+    if (!no_drv && (node->vnode->vtype == VNODE_TYPE_DIR || node->vnode->vtype == VNODE_TYPE_REG || node->vnode->vtype == VNODE_TYPE_LNK))
     {
         if (parent_mnt->fs_driver->driver->header.flags & DRIVER_HEADER_DIRENT_CB_PATHS)
         {
@@ -265,7 +275,7 @@ OBOS_EXPORT obos_status Vfs_UnlinkNode(dirent* node)
     return OBOS_STATUS_SUCCESS;
 }
 
-obos_status Vfs_RenameNode(dirent* node, dirent* newparent, const char* name)
+obos_status Vfs_RenameNode(dirent* node, dirent* newparent, const char* name, bool no_drv)
 {
     if (!node)
         return OBOS_STATUS_INVALID_ARGUMENT;
@@ -291,26 +301,30 @@ obos_status Vfs_RenameNode(dirent* node, dirent* newparent, const char* name)
     if (obos_is_error(status))
         return status;
 
+    if (!header->ftable.move_desc_to && !no_drv)
+        return OBOS_STATUS_UNIMPLEMENTED;
+
     // Rename the entry
     if (!newparent || newparent == node->d_parent)
     {
-        if (!header->ftable.move_desc_to)
-            return OBOS_STATUS_UNIMPLEMENTED;
         if (!name)
             return OBOS_STATUS_INVALID_ARGUMENT;
 
         obos_status status = OBOS_STATUS_SUCCESS;
-        if (header->flags & DRIVER_HEADER_DIRENT_CB_PATHS)
+        if (!no_drv)
         {
-            mount* mount = Vfs_GetVnodeMount(node->vnode);
-            if (!mount)
-                return OBOS_STATUS_INTERNAL_ERROR;
-            char* node_path = VfsH_DirentPath(node, mount->root);
-            status = header->ftable.pmove_desc_to(mount->device, node_path, nullptr, name);
-            Vfs_Free(node_path);
+            if (header->flags & DRIVER_HEADER_DIRENT_CB_PATHS)
+            {
+                mount* mount = Vfs_GetVnodeMount(node->vnode);
+                if (!mount)
+                    return OBOS_STATUS_INTERNAL_ERROR;
+                char* node_path = VfsH_DirentPath(node, mount->root);
+                status = header->ftable.pmove_desc_to(mount->device, node_path, nullptr, name);
+                Vfs_Free(node_path);
+            }
+            else
+                status = header->ftable.move_desc_to(node->vnode->desc, 0, name);
         }
-        else
-            status = header->ftable.move_desc_to(node->vnode->desc, 0, name);
 
         if (obos_is_success(status))
         {
@@ -324,19 +338,22 @@ obos_status Vfs_RenameNode(dirent* node, dirent* newparent, const char* name)
     if (newparent && !name)
     {
         obos_status status = OBOS_STATUS_SUCCESS;
-        if (header->flags & DRIVER_HEADER_DIRENT_CB_PATHS)
+        if (!no_drv)
         {
-            mount* mount = Vfs_GetVnodeMount(node->vnode);
-            if (!mount)
-                return OBOS_STATUS_INTERNAL_ERROR;
-            char* node_path = VfsH_DirentPath(node, mount->root);
-            char* parent_path = VfsH_DirentPath(newparent, mount->root);
-            status = header->ftable.pmove_desc_to(mount->device, node_path, parent_path, nullptr);
-            Vfs_Free(parent_path);
-            Vfs_Free(node_path);
+            if (header->flags & DRIVER_HEADER_DIRENT_CB_PATHS)
+            {
+                mount* mount = Vfs_GetVnodeMount(node->vnode);
+                if (!mount)
+                    return OBOS_STATUS_INTERNAL_ERROR;
+                char* node_path = VfsH_DirentPath(node, mount->root);
+                char* parent_path = VfsH_DirentPath(newparent, mount->root);
+                status = header->ftable.pmove_desc_to(mount->device, node_path, parent_path, nullptr);
+                Vfs_Free(parent_path);
+                Vfs_Free(node_path);
+            }
+            else
+                status = header->ftable.move_desc_to(node->vnode->desc, newparent->vnode->desc, nullptr);
         }
-        else
-            status = header->ftable.move_desc_to(node->vnode->desc, newparent->vnode->desc, nullptr);
 
         if (obos_is_success(status))
         {
@@ -354,20 +371,23 @@ obos_status Vfs_RenameNode(dirent* node, dirent* newparent, const char* name)
     // Move and rename the entry.
 
     status = OBOS_STATUS_SUCCESS;
-    if (header->flags & DRIVER_HEADER_DIRENT_CB_PATHS)
+    if (!no_drv)
     {
-        mount* mount = Vfs_GetVnodeMount(node->vnode);
-        if (!mount)
-            return OBOS_STATUS_INTERNAL_ERROR;
+        if (header->flags & DRIVER_HEADER_DIRENT_CB_PATHS)
+        {
+            mount* mount = Vfs_GetVnodeMount(node->vnode);
+            if (!mount)
+                return OBOS_STATUS_INTERNAL_ERROR;
 
-        char* node_path = VfsH_DirentPath(node, mount->root);
-        char* parent_path = VfsH_DirentPath(newparent, mount->root);
-        status = header->ftable.pmove_desc_to(mount->device, node_path, parent_path, name);
-        Vfs_Free(parent_path);
-        Vfs_Free(node_path);
+            char* node_path = VfsH_DirentPath(node, mount->root);
+            char* parent_path = VfsH_DirentPath(newparent, mount->root);
+            status = header->ftable.pmove_desc_to(mount->device, node_path, parent_path, name);
+            Vfs_Free(parent_path);
+            Vfs_Free(node_path);
+        }
+        else
+            status = header->ftable.move_desc_to(node->vnode->desc, newparent->vnode->desc, name);
     }
-    else
-        status = header->ftable.move_desc_to(node->vnode->desc, newparent->vnode->desc, name);
 
     if (obos_is_success(status))
     {

--- a/src/oboskrnl/vfs/create.h
+++ b/src/oboskrnl/vfs/create.h
@@ -25,14 +25,16 @@
     (_status);\
 })
 
+// If bit 31 of vtype is set, then the filesystem driver is NOT notified of the file creation.
+
 obos_status Vfs_CreateNode(dirent* parent, const char* name, uint32_t vtype, file_perm mode);
 obos_status Vfs_CreateNodeOwner(dirent* parent, const char* name, uint32_t vtype, file_perm mode, uid uid, gid gid);
 
-OBOS_EXPORT obos_status Vfs_UnlinkNode(dirent* node);
+OBOS_EXPORT obos_status Vfs_UnlinkNode(dirent* node, bool no_drv);
 
-obos_status Vfs_TruncateFile(vnode* vn, size_t new_size);
+obos_status Vfs_TruncateFile(vnode* vn, size_t new_size, bool no_drv);
 
-obos_status Vfs_RenameNode(dirent* node, dirent* newparent, const char* name);
+obos_status Vfs_RenameNode(dirent* node, dirent* newparent, const char* name, bool no_drv);
 
 // Updates the file times of the vnode
 // in the underlying filesystem.

--- a/src/oboskrnl/vfs/dirent.c
+++ b/src/oboskrnl/vfs/dirent.c
@@ -321,8 +321,6 @@ static dirent* lookup(const char* path, dirent* root_par, bool only_cache)
             new->vnode->refs++;
             if (new_vn->vtype == VNODE_TYPE_LNK && !new_vn->un.linked)
                 mountpoint->fs_driver->driver->header.ftable.get_linked_path(new_vn->desc, &new_vn->un.linked);
-            if (new_vn->vtype == VNODE_TYPE_DIR)
-                new_vn->tmpfs_directory_entry = new;
         }
         if (!new->d_prev_child && !new->d_next_child && last->d_children.head != new && last != new)
             VfsH_DirentAppendChild(last ? last : mountpoint->root, new);
@@ -598,9 +596,6 @@ static iterate_decision populate_cb(dev_desc desc, size_t blkSize, size_t blkCou
     OBOS_InitString(&new->name, name);
     new->vnode = vn;
     VfsH_DirentAppendChild(dent, new);
-    
-    if (vn->vtype == VNODE_TYPE_DIR)
-        vn->tmpfs_directory_entry = new;
 
     LIST_APPEND(dirent_list, &point->dirent_list, new);
     return ITERATE_DECISION_CONTINUE;

--- a/src/oboskrnl/vfs/dirent.c
+++ b/src/oboskrnl/vfs/dirent.c
@@ -96,7 +96,7 @@ static dirent* on_match(dirent** const curr_, dirent** const root, const char** 
                 currentPathLen--;
         }
         thread* cur_thr = Core_GetCurrentThread();
-        if (curr->flags & DIRENT_REFERS_CTTY || curr->vnode->flags & VFLAGS_REFERS_CTTY)
+        if (curr->flags & DIRENT_REFERS_CTTY || (curr->vnode && curr->vnode->flags & VFLAGS_REFERS_CTTY))
         {
             if (!(cur_thr && cur_thr->proc && cur_thr->proc->session && cur_thr->proc->session->controlling_tty))
                 return nullptr;

--- a/src/oboskrnl/vfs/dirent.c
+++ b/src/oboskrnl/vfs/dirent.c
@@ -103,7 +103,8 @@ static dirent* on_match(dirent** const curr_, dirent** const root, const char** 
             return cur_thr->proc->session->controlling_tty->ent;
         }
 
-        if (!only_cache)
+        bool vnode_is_drv = curr->vnode && (curr->vnode->vtype == VNODE_TYPE_DIR || curr->vnode->vtype == VNODE_TYPE_REG || curr->vnode->vtype == VNODE_TYPE_LNK);
+        if (!only_cache && vnode_is_drv)
         {
             dev_desc desc = 0;
             driver_header* header = Vfs_GetVnodeDriver(curr->d_parent->vnode);
@@ -285,7 +286,7 @@ static dirent* lookup(const char* path, dirent* root_par, bool only_cache)
     size_t currentPathLen = 0;
     vdev* fs_driver = lastMount->fs_driver;
     mount* mountpoint = lastMount;
-    dirent* last = root_par;
+    dirent* last = Vfs_GetRoot() == root_par ? mountpoint->root : root_par;
     while (tok < (path_mnt+path_mnt_len))
     {
         char* token = Vfs_Calloc(tok_len + 1, sizeof(char));

--- a/src/oboskrnl/vfs/dirent.c
+++ b/src/oboskrnl/vfs/dirent.c
@@ -17,6 +17,7 @@
 #include <vfs/vnode.h>
 #include <vfs/limits.h>
 #include <vfs/tmpfs.h>
+#include <vfs/create.h>
 
 #include <allocators/base.h>
 
@@ -79,7 +80,7 @@ static vnode* create_vnode(mount* mountpoint, dev_desc desc)
     return vn;
 }
 static dirent* on_match(dirent** const curr_, dirent** const root, const char** const tok, size_t* const tok_len, const char** const path, 
-                        size_t* const path_len, size_t* const lastMountPoint, mount** const lastMount)
+                        size_t* const path_len, size_t* const lastMountPoint, mount** const lastMount, bool only_cache)
 {
     dirent *curr = *curr_;
     *root = curr;
@@ -95,12 +96,31 @@ static dirent* on_match(dirent** const curr_, dirent** const root, const char** 
                 currentPathLen--;
         }
         thread* cur_thr = Core_GetCurrentThread();
-        if (curr->flags & DIRENT_REFERS_CTTY)
+        if (curr->flags & DIRENT_REFERS_CTTY || curr->vnode->flags & VFLAGS_REFERS_CTTY)
         {
             if (!(cur_thr && cur_thr->proc && cur_thr->proc->session && cur_thr->proc->session->controlling_tty))
                 return nullptr;
             return cur_thr->proc->session->controlling_tty->ent;
         }
+
+        if (!only_cache)
+        {
+            dev_desc desc = 0;
+            driver_header* header = Vfs_GetVnodeDriver(curr->d_parent->vnode);
+            mount* mountpoint = Vfs_GetVnodeMount(curr->d_parent->vnode);
+            if (!header || !header->ftable.path_search)
+                return curr;
+            obos_status status = header->ftable.path_search(&desc, mountpoint->device, OBOS_GetStringCPtr(&curr->name), curr->d_parent->vnode->desc);
+            if (obos_is_error(status))
+            {
+                VfsH_DirentRemoveChild(curr->d_parent, curr);
+                OBOS_FreeString(&curr->name);
+                Vfs_Free(curr);
+                *curr_ = nullptr;
+                return nullptr; // The file was deleted on another mountpoint.
+            }
+        }
+
         return curr;
     }
     if (!curr->d_children.nChildren)
@@ -202,7 +222,9 @@ static dirent* lookup(const char* path, dirent* root_par, bool only_cache)
         {
             // Match!
             dirent* what = 
-                on_match(&curr, &root, &tok, &tok_len, &path, &path_len, &lastMountPoint, &lastMount);
+                on_match(&curr, &root, &tok, &tok_len, &path, &path_len, &lastMountPoint, &lastMount, only_cache);
+            if (!curr)
+                return nullptr;
             root = curr->d_children.head;
             if (what)
                 return what;
@@ -215,7 +237,9 @@ static dirent* lookup(const char* path, dirent* root_par, bool only_cache)
             {
                 // Match!
                 dirent* what = 
-                    on_match(&curr, &root, &tok, &tok_len, &path, &path_len, &lastMountPoint, &lastMount);
+                    on_match(&curr, &root, &tok, &tok_len, &path, &path_len, &lastMountPoint, &lastMount, only_cache);
+                if (!curr)
+                    return nullptr;
                 if (what)
                     return what;
                 // else
@@ -559,7 +583,10 @@ static iterate_decision populate_cb(dev_desc desc, size_t blkSize, size_t blkCou
     for (dirent* child = dent->d_children.head; child; )
     {
         if (OBOS_CompareStringC(&child->name, name))
+        {
+            child->flags &= ~DIRENT_FREE;
             return ITERATE_DECISION_CONTINUE;
+        }
 
         child = child->d_next_child;
     }
@@ -571,8 +598,10 @@ static iterate_decision populate_cb(dev_desc desc, size_t blkSize, size_t blkCou
     OBOS_InitString(&new->name, name);
     new->vnode = vn;
     VfsH_DirentAppendChild(dent, new);
+    
     if (vn->vtype == VNODE_TYPE_DIR)
         vn->tmpfs_directory_entry = new;
+
     LIST_APPEND(dirent_list, &point->dirent_list, new);
     return ITERATE_DECISION_CONTINUE;
 }
@@ -585,9 +614,20 @@ void Vfs_PopulateDirectory(dirent* dent)
         return;
     if (driver->ftable.list_dir)
     {
+        for (dirent* ent = dent->d_children.head; ent; ent = ent->d_next_child)
+            ent->flags |= DIRENT_FREE;
+
         obos_status status = driver->ftable.list_dir(dent->vnode->flags & VFLAGS_MOUNTPOINT ? UINTPTR_MAX : dent->vnode->desc, point->device, populate_cb, dent);
         if (obos_is_error(status))
             OBOS_Error("list_dir returned %d!\n", status);
+
+        for (dirent* ent = dent->d_children.head; ent; )
+        {
+            dirent* const next = ent->d_next_child;
+            if (ent->flags & DIRENT_FREE)
+                Vfs_UnlinkNode(ent, true);
+            ent = next;
+        }
     }
     else
         OBOS_Error("driver->ftable.list_dir == nullptr!\n");

--- a/src/oboskrnl/vfs/dirent.c
+++ b/src/oboskrnl/vfs/dirent.c
@@ -16,6 +16,7 @@
 #include <vfs/mount.h>
 #include <vfs/vnode.h>
 #include <vfs/limits.h>
+#include <vfs/tmpfs.h>
 
 #include <allocators/base.h>
 
@@ -37,7 +38,7 @@ static size_t str_search(const char* str, char ch)
         ;
     return ret;
 }
-static vnode* create_vnode(mount* mountpoint, dev_desc desc, file_type* t)
+static vnode* create_vnode(mount* mountpoint, dev_desc desc)
 {
     if (mountpoint->fs_driver->driver->header.ftable.vnode_search)
     {
@@ -47,21 +48,6 @@ static vnode* create_vnode(mount* mountpoint, dev_desc desc, file_type* t)
         {
             OBOS_ENSURE(vn);
             vn->mount_point = mountpoint;
-            if (t)
-            {
-                switch (vn->vtype) {
-                    case VNODE_TYPE_LNK:
-                        *t = FILE_TYPE_SYMBOLIC_LINK;
-                        break;
-                    case VNODE_TYPE_REG:
-                        *t = FILE_TYPE_REGULAR_FILE;
-                        break;
-                    case VNODE_TYPE_DIR:
-                        *t = FILE_TYPE_DIRECTORY;
-                        break;
-                    default: OBOS_UNREACHABLE;
-                }
-            }
             return vn;
         }
     }
@@ -90,8 +76,6 @@ static vnode* create_vnode(mount* mountpoint, dev_desc desc, file_type* t)
     memcpy(&vn->perm, &perm, sizeof(file_perm));
     if (mountpoint->fs_driver->driver->header.ftable.get_file_inode)
         mountpoint->fs_driver->driver->header.ftable.get_file_inode(desc, &vn->inode);
-    if (t)
-        *t = type;
     return vn;
 }
 static dirent* on_match(dirent** const curr_, dirent** const root, const char** const tok, size_t* const tok_len, const char** const path, 
@@ -295,7 +279,6 @@ static dirent* lookup(const char* path, dirent* root_par, bool only_cache)
         if (!new)
         {
             dev_desc curdesc = 0;
-            file_type curtype = 0;
             obos_status status = fs_driver->driver->header.ftable.path_search(&curdesc, mountpoint->device, token, last->vnode->desc);
             if (obos_is_error(status))
             {
@@ -309,12 +292,12 @@ static dirent* lookup(const char* path, dirent* root_par, bool only_cache)
             OBOS_StringSetAllocator(&new->name, Vfs_Allocator);
             OBOS_InitStringLen(&new->name, token, tok_len);
             // mountpoint->fs_driver->driver->header.ftable.get_file_type(desc, &type);
-            vnode* new_vn = create_vnode(mountpoint, curdesc, &curtype);
+            vnode* new_vn = create_vnode(mountpoint, curdesc);
             new->vnode = new_vn;
             new->vnode->refs++;
-            if (curtype == FILE_TYPE_SYMBOLIC_LINK && !new_vn->un.linked)
+            if (new_vn->vtype == VNODE_TYPE_LNK && !new_vn->un.linked)
                 mountpoint->fs_driver->driver->header.ftable.get_linked_path(new_vn->desc, &new_vn->un.linked);
-            if (curtype == FILE_TYPE_DIRECTORY)
+            if (new_vn->vtype == VNODE_TYPE_DIR)
                 new_vn->tmpfs_directory_entry = new;
         }
         if (!new->d_prev_child && !new->d_next_child && last->d_children.head != new && last != new)
@@ -485,8 +468,6 @@ static long get_current_time()
     return current_time;
 }
 
-static uint32_t devfs_inode = 3;
-
 vnode* Drv_AllocateVNode(driver_id* drv, dev_desc desc, size_t filesize, vdev** dev_p, uint32_t type)
 {
     static file_perm default_fileperm = {
@@ -515,14 +496,13 @@ vnode* Drv_AllocateVNode(driver_id* drv, dev_desc desc, size_t filesize, vdev** 
     vn->desc = desc;
     vn->filesize = filesize;
     vn->un.device = dev;
-    vn->inode = devfs_inode++;
     vn->perm = default_fileperm;
     vn->vtype = type;
     vn->gid = ROOT_GID;
     vn->uid = ROOT_UID;
     vn->times.access = get_current_time();
     vn->times.birth = vn->times.access;
-    vn->times.change = vn->times.access;
+    vn->times.change = vn->times.access;    
     if (dev_p)
         *dev_p = dev;
     return vn;    
@@ -536,7 +516,7 @@ dirent* Drv_RegisterVNodeEx(struct vnode* vn, const char* const dev_name, int fl
 {
     if (!vn || !dev_name)
         return nullptr;
-    dirent* parent = Vfs_DevRoot;
+    dirent* parent = ((tmpfs*)Vfs_Devfs->data)->root;
     if (flags & REGISTER_VNODE_IS_PTY)
         parent = VfsH_DirentLookupFrom("pts", parent);
     if (!parent)
@@ -561,7 +541,10 @@ dirent* Drv_RegisterVNodeEx(struct vnode* vn, const char* const dev_name, int fl
     ent->vnode->mount_point = point;
     OBOS_StringSetAllocator(&ent->name, Vfs_Allocator);
     OBOS_InitString(&ent->name, dev_name);
+
+    Vfs_TmpFSMakeVnode(((tmpfs*)Vfs_Devfs->data), vn, ent);
     VfsH_DirentAppendChild(parent, ent);
+    
     VfsH_UnlockMountpoint(point);
 
     return ent;
@@ -582,7 +565,7 @@ static iterate_decision populate_cb(dev_desc desc, size_t blkSize, size_t blkCou
     }
 
     mount* point = Vfs_GetVnodeMount(dent->vnode);
-    vnode* vn = create_vnode(point, desc, nullptr);
+    vnode* vn = create_vnode(point, desc);
     dirent* new = Vfs_Calloc(1, sizeof(dirent));
     OBOS_StringSetAllocator(&new->name, Vfs_Allocator);
     OBOS_InitString(&new->name, name);

--- a/src/oboskrnl/vfs/dirent.c
+++ b/src/oboskrnl/vfs/dirent.c
@@ -65,11 +65,11 @@ static vnode* create_vnode(mount* mountpoint, dev_desc desc, file_type* t)
             return vn;
         }
     }
+    vnode* vn = Vfs_Calloc(1, sizeof(vnode));
     file_type type = 0;
     driver_file_perm perm = {};
     mountpoint->fs_driver->driver->header.ftable.get_file_perms(desc, &perm);
     mountpoint->fs_driver->driver->header.ftable.get_file_type(desc, &type);
-    vnode* vn = Vfs_Calloc(1, sizeof(vnode));
     switch (type)
     {
         case FILE_TYPE_REGULAR_FILE:
@@ -88,6 +88,8 @@ static vnode* create_vnode(mount* mountpoint, dev_desc desc, file_type* t)
     vn->mount_point = mountpoint;
     vn->desc = desc;
     memcpy(&vn->perm, &perm, sizeof(file_perm));
+    if (mountpoint->fs_driver->driver->header.ftable.get_file_inode)
+        mountpoint->fs_driver->driver->header.ftable.get_file_inode(desc, &vn->inode);
     if (t)
         *t = type;
     return vn;
@@ -312,6 +314,8 @@ static dirent* lookup(const char* path, dirent* root_par, bool only_cache)
             new->vnode->refs++;
             if (curtype == FILE_TYPE_SYMBOLIC_LINK && !new_vn->un.linked)
                 mountpoint->fs_driver->driver->header.ftable.get_linked_path(new_vn->desc, &new_vn->un.linked);
+            if (curtype == FILE_TYPE_DIRECTORY)
+                new_vn->tmpfs_directory_entry = new;
         }
         if (!new->d_prev_child && !new->d_next_child && last->d_children.head != new && last != new)
             VfsH_DirentAppendChild(last ? last : mountpoint->root, new);
@@ -461,6 +465,8 @@ void VfsH_DirentRemoveChild(dirent* parent, dirent* what)
     if (parent->d_children.tail == what)
         parent->d_children.tail = what->d_prev_child;
     parent->d_children.nChildren--;
+    what->d_next_child = nullptr;
+    what->d_prev_child = nullptr;
     what->d_parent = nullptr; // we're now an orphan :(
     mount* const point = parent->vnode->mount_point ? parent->vnode->mount_point : parent->vnode->un.mounted;
     LIST_REMOVE(dirent_list, &point->dirent_list, what);
@@ -582,6 +588,8 @@ static iterate_decision populate_cb(dev_desc desc, size_t blkSize, size_t blkCou
     OBOS_InitString(&new->name, name);
     new->vnode = vn;
     VfsH_DirentAppendChild(dent, new);
+    if (vn->vtype == VNODE_TYPE_DIR)
+        vn->tmpfs_directory_entry = new;
     LIST_APPEND(dirent_list, &point->dirent_list, new);
     return ITERATE_DECISION_CONTINUE;
 }

--- a/src/oboskrnl/vfs/dirent.h
+++ b/src/oboskrnl/vfs/dirent.h
@@ -18,6 +18,7 @@ enum {
     // This dirent hard links to the controlling tty of the process
     DIRENT_REFERS_CTTY = BIT(0),
     DIRENT_TMPFS_FILE_MOVED = BIT(1),
+    DIRENT_FREE = BIT(2),
 };
 
 typedef LIST_HEAD(dirent_list, struct dirent) dirent_list;

--- a/src/oboskrnl/vfs/dirent.h
+++ b/src/oboskrnl/vfs/dirent.h
@@ -1,7 +1,7 @@
 /*
  * oboskrnl/vfs/dirent.h
  *
- * Copyright (c) 2024 Omar Berrow
+ * Copyright (c) 2024-2026 Omar Berrow
 */
 
 #pragma once
@@ -17,6 +17,7 @@
 enum {
     // This dirent hard links to the controlling tty of the process
     DIRENT_REFERS_CTTY = BIT(0),
+    DIRENT_TMPFS_FILE_MOVED = BIT(1),
 };
 
 typedef LIST_HEAD(dirent_list, struct dirent) dirent_list;

--- a/src/oboskrnl/vfs/dummy_devices.c
+++ b/src/oboskrnl/vfs/dummy_devices.c
@@ -24,6 +24,7 @@
 #include <vfs/vnode.h>
 #include <vfs/alloc.h>
 #include <vfs/mount.h>
+#include <vfs/tmpfs.h>
 
 #include <irq/timer.h>
 
@@ -477,8 +478,9 @@ static void init_desc(dev_desc desc)
         }
     }
 
-    dirent* parent = Vfs_DevRoot;
+    dirent* parent = ((tmpfs*)(Vfs_Devfs->data))->root;
     vn->mount_point = parent->vnode->mount_point;
+    Vfs_TmpFSMakeVnode((tmpfs*)(Vfs_Devfs->data), vn, ent);
     VfsH_DirentAppendChild(parent, ent);
 }
 

--- a/src/oboskrnl/vfs/fd.c
+++ b/src/oboskrnl/vfs/fd.c
@@ -145,7 +145,7 @@ OBOS_EXPORT obos_status Vfs_FdOpenVnode(fd* const desc, void* vn, uint32_t oflag
 
     if (oflags & FD_OFLAGS_TRUNCATE && desc->vn->vtype == VNODE_TYPE_REG && (desc->flags & FD_FLAGS_WRITE))
     {
-        obos_status status = Vfs_TruncateFile(desc->vn, 0);
+        obos_status status = Vfs_TruncateFile(desc->vn, 0, false);
         if (obos_is_error(status))
             OBOS_Debug("%s: Vfs_TruncateFile returned %d!\n", __func__, status);
     }

--- a/src/oboskrnl/vfs/fd.c
+++ b/src/oboskrnl/vfs/fd.c
@@ -119,7 +119,7 @@ OBOS_EXPORT obos_status Vfs_FdOpenVnode(fd* const desc, void* vn, uint32_t oflag
     }
     desc->vn->refs++;
     LIST_APPEND(fd_list, &desc->vn->opened, desc);
-    if (~desc->vn->flags & VFLAGS_EVENT_DEV)
+    if (~desc->vn->flags & VFLAGS_EVENT_DEV && ~desc->vn->flags & VFLAGS_TMPFS)
     {
         driver_header* driver = Vfs_GetVnodeDriver(vn);
         desc->desc = desc->vn->desc;

--- a/src/oboskrnl/vfs/fd_sys.c
+++ b/src/oboskrnl/vfs/fd_sys.c
@@ -1287,7 +1287,7 @@ obos_status Sys_OpenTmpFS(handle ufd, int type, OBOS_MAYBE_UNUSED int flags, han
             backend_fs = overlay_vn;
         }
 
-        status = Vfs_TmpFSCreate(&tmpfs_vn, &backend->header, backend_fs);
+        status = Vfs_TmpFSCreate(&tmpfs_vn, backend ? &backend->header : nullptr, backend_fs);
         if (obos_is_error(status))
             return status;
     }

--- a/src/oboskrnl/vfs/fd_sys.c
+++ b/src/oboskrnl/vfs/fd_sys.c
@@ -1113,6 +1113,8 @@ static driver_id* detect_fs_driver(vnode* vn)
 {
     if (vn->nPartitions == 1)
         return vn->partitions[0].fs_driver;
+    else if (vn->flags & VFLAGS_TMPFS)
+        return &OBOS_TmpFSDriver;
     else
         return nullptr;
 } 

--- a/src/oboskrnl/vfs/fd_sys.c
+++ b/src/oboskrnl/vfs/fd_sys.c
@@ -1166,6 +1166,49 @@ obos_status Sys_Mount(const char* uat, const char* uon)
     return status;
 }
 
+obos_status Sys_Mount2(const char* uat, handle on)
+{
+    char* at = nullptr;
+    size_t sz_path = 0;
+    obos_status status = OBOS_STATUS_SUCCESS;
+    handle_desc* fd = nullptr;
+
+    if (!uat)
+        return OBOS_STATUS_INVALID_ARGUMENT;
+
+    status = OBOS_CapabilityCheck("fs/mount", false);
+    if (obos_is_error(status))
+        return status;
+
+    status = OBOSH_ReadUserString(uat, nullptr, &sz_path);
+    if (obos_is_error(status))
+        return status;
+    at = ZeroAllocate(OBOS_KernelAllocator, sz_path+1, sizeof(char), nullptr);
+    OBOSH_ReadUserString(uat, at, nullptr);
+
+    OBOS_LockHandleTable(OBOS_CurrentHandleTable());
+    fd = OBOS_HandleLookup(OBOS_CurrentHandleTable(), on, HANDLE_TYPE_FD, false, &status);
+    if (!fd)
+    {
+        OBOS_UnlockHandleTable(OBOS_CurrentHandleTable());
+        goto done;
+    }
+    OBOS_UnlockHandleTable(OBOS_CurrentHandleTable());
+    if (~fd->un.fd->flags & FD_FLAGS_OPEN || !fd->un.fd->vn)
+        goto done;
+
+    vdev dev = { .driver=detect_fs_driver(fd->un.fd->vn) };
+    if (!dev.driver)
+        status = OBOS_STATUS_INVALID_ARGUMENT;
+    else
+        status = Vfs_Mount(at, fd->un.fd->vn, &dev, nullptr);
+
+    done:
+    Free(OBOS_KernelAllocator, at, sz_path+1);
+
+    return status;
+}
+
 obos_status Sys_Unmount(const char* uat)
 {
     obos_status status = OBOS_CapabilityCheck("fs/unmount", false);

--- a/src/oboskrnl/vfs/fd_sys.c
+++ b/src/oboskrnl/vfs/fd_sys.c
@@ -39,6 +39,7 @@
 #include <vfs/irp.h>
 #include <vfs/create.h>
 #include <vfs/socket.h>
+#include <vfs/tmpfs.h>
 
 #include <locks/event.h>
 #include <locks/wait.h>
@@ -1186,6 +1187,69 @@ obos_status Sys_Unmount(const char* uat)
     return status;
 }
 
+obos_status Sys_OpenTmpFS(handle ufd, int type, OBOS_MAYBE_UNUSED int flags, handle uoverlay)
+{
+    obos_status status = OBOS_STATUS_SUCCESS;
+    vnode* tmpfs_vn = nullptr;
+    handle_desc* fd = nullptr;
+
+    OBOS_LockHandleTable(OBOS_CurrentHandleTable());
+    fd = OBOS_HandleLookup(OBOS_CurrentHandleTable(), ufd, HANDLE_TYPE_FD, false, &status);
+    if (!fd)
+    {
+        OBOS_UnlockHandleTable(OBOS_CurrentHandleTable());
+        return status;
+    }
+    OBOS_UnlockHandleTable(OBOS_CurrentHandleTable());
+
+    if (!fd->un.fd)
+        return OBOS_STATUS_UNINITIALIZED;
+    
+    if (fd->un.fd->flags & FD_FLAGS_OPEN)
+        return OBOS_STATUS_ALREADY_INITIALIZED;
+
+    switch (type) {
+        case TMPFS_INITRD: tmpfs_vn = Vfs_InitrdTmpfs; break;
+        case TMPFS_DEVFS: tmpfs_vn = Vfs_Devfs; break;
+        case TMPFS_NEW:
+        case TMPFS_OVERLAY: tmpfs_vn = nullptr; break;
+        default: return OBOS_STATUS_INVALID_ARGUMENT;
+    }
+
+    if (!tmpfs_vn)
+    {
+        driver_id* backend = nullptr;
+        void* backend_fs = nullptr;
+
+        if (type == TMPFS_OVERLAY)
+        {
+            handle_desc* overlay = nullptr;
+            vnode* overlay_vn = nullptr;
+
+            OBOS_LockHandleTable(OBOS_CurrentHandleTable());
+            overlay = OBOS_HandleLookup(OBOS_CurrentHandleTable(), uoverlay, HANDLE_TYPE_FD, false, &status);
+            if (!overlay)
+            {
+                OBOS_UnlockHandleTable(OBOS_CurrentHandleTable());
+                return status;
+            }
+            OBOS_UnlockHandleTable(OBOS_CurrentHandleTable());
+
+            overlay_vn = overlay->un.fd->vn;
+            backend = detect_fs_driver(overlay_vn);
+            if (!backend)
+                return OBOS_STATUS_INVALID_ARGUMENT;
+            backend_fs = overlay_vn;
+        }
+
+        status = Vfs_TmpFSCreate(&tmpfs_vn, &backend->header, backend_fs);
+        if (obos_is_error(status))
+            return status;
+    }
+
+    return Vfs_FdOpenVnode(fd->un.fd, tmpfs_vn, FD_OFLAGS_READ|FD_OFLAGS_WRITE|FD_OFLAGS_UNCACHED);
+}
+
 obos_status Sys_IRPCreate(handle *ufile, size_t offset, size_t size, enum irp_op operation, void* buffer)
 {
     obos_status status = OBOS_STATUS_SUCCESS;
@@ -1205,6 +1269,7 @@ obos_status Sys_IRPCreate(handle *ufile, size_t offset, size_t size, enum irp_op
         return status;
 
     vnode* vn = nullptr;
+    OBOS_LockHandleTable(OBOS_CurrentHandleTable());
     handle_desc* fd = OBOS_HandleLookup(OBOS_CurrentHandleTable(), file, HANDLE_TYPE_FD, false, &status);
     if (!fd)
     {

--- a/src/oboskrnl/vfs/fd_sys.c
+++ b/src/oboskrnl/vfs/fd_sys.c
@@ -803,7 +803,7 @@ obos_status Sys_UnlinkAt(handle parent, const char* upath, int flags)
     if (node->vnode->vtype == VNODE_TYPE_DIR && node->tree_info.children.nChildren)
         return OBOS_STATUS_IN_USE;
     
-    return Vfs_UnlinkNode(node);
+    return Vfs_UnlinkNode(node, false);
 }
 
 obos_status Sys_ReadLinkAt(handle parent, const char *upath, void* ubuff, size_t max_size, size_t* length)
@@ -2310,7 +2310,7 @@ obos_status Sys_RenameAt(handle olddirfd, const char *uoldname, handle newdirfd,
         return OBOS_STATUS_ALREADY_INITIALIZED;
     }
     
-    status = Vfs_RenameNode(dtarget, pnewname, newfilename);
+    status = Vfs_RenameNode(dtarget, pnewname, newfilename, false);
 
     Free(OBOS_KernelAllocator, link, sz_path+1);
 

--- a/src/oboskrnl/vfs/fd_sys.h
+++ b/src/oboskrnl/vfs/fd_sys.h
@@ -329,6 +329,13 @@ obos_status Sys_OpenTmpFS(handle fd, int type, int flags, handle overlay);
 /// <returns>An obos_status.</returns>
 obos_status Sys_Mount(const char* at, const char* on);
 /// <summary>
+/// Mounts a file system.
+/// </summary>
+/// <param name="at">The root directory to mount on</param>
+/// <param name="on">The file system to mount</param>
+/// <returns>An obos_status.</returns>
+obos_status Sys_Mount2(const char* at, handle on);
+/// <summary>
 /// Unmounts a file system.
 /// </summary>
 /// <param name="at">The directory to unmount</param>

--- a/src/oboskrnl/vfs/fd_sys.h
+++ b/src/oboskrnl/vfs/fd_sys.h
@@ -313,6 +313,14 @@ obos_status Sys_ReadEntries(handle dent, void* buffer, size_t szBuf, size_t* nRe
 // Internal use only
 void OBOS_OpenStandardFDs(struct handle_table* tbl);
 
+enum {
+    TMPFS_INITRD,
+    TMPFS_DEVFS,
+    TMPFS_NEW,
+    TMPFS_OVERLAY,
+};
+obos_status Sys_OpenTmpFS(handle fd, int type, int flags, handle overlay);
+
 /// <summary>
 /// Mounts a file system.
 /// </summary>

--- a/src/oboskrnl/vfs/init.c
+++ b/src/oboskrnl/vfs/init.c
@@ -221,5 +221,6 @@ OBOS_PAGEABLE_FUNCTION void Vfs_FinalizeInitialization()
         vnode* dev_tty_vn = Drv_AllocateVNode(nullptr, 0, 0, nullptr, VNODE_TYPE_CHR);
         dirent* dev_tty = Drv_RegisterVNode(dev_tty_vn, "tty");
         dev_tty->flags |= DIRENT_REFERS_CTTY;
+        dev_tty_vn->flags |= VFLAGS_REFERS_CTTY;
     } while(0);
 }

--- a/src/oboskrnl/vfs/init.c
+++ b/src/oboskrnl/vfs/init.c
@@ -1,7 +1,7 @@
 /*
  * oboskrnl/vfs/init.c
  *
- * Copyright (c) 2024 Omar Berrow
+ * Copyright (c) 2024-2026 Omar Berrow
 */
 
 #include <int.h>
@@ -22,6 +22,7 @@
 #include <vfs/create.h>
 #include <vfs/socket.h>
 #include <vfs/tty.h>
+#include <vfs/tmpfs.h>
 
 #include <mm/alloc.h>
 #include <mm/context.h>
@@ -109,7 +110,14 @@ void Vfs_Initialize()
         Vfs_DevRoot->vnode->perm = perm;
         return;
     }
-    Vfs_Mount("/", nullptr, &initrd_dev, &Vfs_Root->vnode->mount_point);
+    
+    vnode* fsd = nullptr;
+    Vfs_TmpFSCreate(&fsd, &initrd_dev.driver->header, nullptr);
+
+    vdev dev = {.driver=&OBOS_TmpFSDriver,.data=nullptr,.desc=fsd->desc};
+
+    Vfs_Mount("/", fsd, &dev, &Vfs_Root->vnode->mount_point);
+
     Vfs_DevRoot = VfsH_DirentLookup(OBOS_DEV_PREFIX);
     if (!Vfs_DevRoot)
         OBOS_Panic(OBOS_PANIC_FATAL_ERROR, "%s: Could not find directory at OBOS_DEV_PREFIX (%s) specified at build time.\n", __func__, OBOS_DEV_PREFIX);

--- a/src/oboskrnl/vfs/init.c
+++ b/src/oboskrnl/vfs/init.c
@@ -111,17 +111,22 @@ void Vfs_Initialize()
         return;
     }
     
-    vnode* fsd = nullptr;
-    Vfs_TmpFSCreate(&fsd, &initrd_dev.driver->header, nullptr);
+    Vfs_TmpFSCreate(&Vfs_InitrdTmpfs, &initrd_dev.driver->header, nullptr);
+    Vfs_TmpFSCreate(&Vfs_Devfs, nullptr, nullptr);
 
-    vdev dev = {.driver=&OBOS_TmpFSDriver,.data=nullptr,.desc=fsd->desc};
+    vdev idev = {.driver=&OBOS_TmpFSDriver,.data=nullptr,.desc=Vfs_InitrdTmpfs->desc};
+    vdev ddev = {.driver=&OBOS_TmpFSDriver,.data=nullptr,.desc=Vfs_Devfs->desc};
 
-    Vfs_Mount("/", fsd, &dev, &Vfs_Root->vnode->mount_point);
-
+    Vfs_Mount("/", Vfs_InitrdTmpfs, &idev, &Vfs_Root->vnode->mount_point);
+    
     Vfs_DevRoot = VfsH_DirentLookup(OBOS_DEV_PREFIX);
     if (!Vfs_DevRoot)
         OBOS_Panic(OBOS_PANIC_FATAL_ERROR, "%s: Could not find directory at OBOS_DEV_PREFIX (%s) specified at build time.\n", __func__, OBOS_DEV_PREFIX);
+    
+    Vfs_Mount(OBOS_DEV_PREFIX, Vfs_Devfs, &ddev, &Vfs_DevRoot->vnode->mount_point);
+    
     OBOS_CapabilityInitialize();
+
     if (root_partid)
         Free(OBOS_KernelAllocator, root_partid, strlen(root_partid)+1);
     if (root_uuid)

--- a/src/oboskrnl/vfs/mount.c
+++ b/src/oboskrnl/vfs/mount.c
@@ -1,7 +1,7 @@
 /*
  * oboskrnl/vfs/mount.c
  *
- * Copyright (c) 2024-2025 Omar Berrow
+ * Copyright (c) 2024-2026 Omar Berrow
 */
 
 #include <int.h>
@@ -31,6 +31,8 @@
 
 struct dirent* Vfs_Root;
 struct dirent* Vfs_DevRoot;
+vnode* Vfs_InitrdTmpfs;
+vnode* Vfs_Devfs;
 mount_list Vfs_Mounted;
 
 static size_t str_search(const char* str, char ch)
@@ -291,6 +293,7 @@ static void stage_two(mount* unused, dirent* ent, void* userdata)
     OBOS_FreeString(&ent->name);
     Vfs_Free(ent);
 }
+
 obos_status Vfs_Unmount(mount* what)
 {
     if (!what)
@@ -326,6 +329,7 @@ obos_status Vfs_Unmount(mount* what)
     }
     return OBOS_STATUS_SUCCESS;
 }
+
 obos_status Vfs_UnmountP(const char* at)
 {
     dirent* resolved = VfsH_DirentLookup(at);

--- a/src/oboskrnl/vfs/mount.c
+++ b/src/oboskrnl/vfs/mount.c
@@ -163,6 +163,7 @@ OBOS_STATIC_ASSERT(sizeof(driver_file_perm) == sizeof(file_perm), "Invalid sizes
 //         fs_driver->driver->header.ftable.list_dir(desc, (void*)udata[2], callback, udata);
 //     return ITERATE_DECISION_CONTINUE;
 // }
+
 obos_status Vfs_Mount(const char* at_, vnode* on, vdev* fs_driver, mount** pMountpoint)
 {
     if (!Vfs_GetRoot())

--- a/src/oboskrnl/vfs/mount.h
+++ b/src/oboskrnl/vfs/mount.h
@@ -1,7 +1,7 @@
 /*
  * oboskrnl/vfs/mount.h
  *
- * Copyright (c) 2024-2025 Omar Berrow
+ * Copyright (c) 2024-2026 Omar Berrow
 */
 
 #pragma once
@@ -31,9 +31,16 @@ typedef struct mount
     atomic_size_t nWaiting;
     bool awaitingFree;
 } mount;
+
 extern struct dirent* Vfs_Root;
-struct dirent* Vfs_GetRoot();
 extern struct dirent* Vfs_DevRoot;
+
+extern vnode* Vfs_InitrdTmpfs;
+extern vnode* Vfs_Devfs;
+
+// Gets the current process' root directory.
+struct dirent* Vfs_GetRoot();
+
 extern mount_list Vfs_Mounted;
 
 // returns true if the operation succeeded.

--- a/src/oboskrnl/vfs/pty.c
+++ b/src/oboskrnl/vfs/pty.c
@@ -376,7 +376,7 @@ static obos_status ptmx_reference_device(dev_desc* desc)
             return status;
         pty* master = (void*)(*desc);
         master->master_refs++;
-        printf("referencing PTS %p master, now at %d master refs, %d refs\n", master, master->master_refs, master->ptr.refs);
+        // printf("referencing PTS %p master, now at %d master refs, %d refs\n", master, master->master_refs, master->ptr.refs);
         tty_interface iface = Vfs_PTSInterface;
         iface.userdata = master;
         return Vfs_RegisterTTY(&iface, &master->slave, TTY_PSUEDO);
@@ -385,7 +385,7 @@ static obos_status ptmx_reference_device(dev_desc* desc)
     pty* master = (void*)(*desc);
     OBOS_SharedPtrRef(&master->ptr);
     master->master_refs++;
-    printf("referencing PTS %p master, now at %d master refs, %d refs\n", master, master->master_refs, master->ptr.refs);
+    // printf("referencing PTS %p master, now at %d master refs, %d refs\n", master, master->master_refs, master->ptr.refs);
 
     return OBOS_STATUS_SUCCESS;
 }
@@ -399,7 +399,7 @@ static obos_status ptmx_unreference_device(dev_desc desc)
     pty* master = (void*)desc;
     
     master->master_refs--;
-    printf("dereferencing PTS %p master, now at %d master refs, %d refs\n", master, master->master_refs, master->ptr.refs-1);
+    // printf("dereferencing PTS %p master, now at %d master refs, %d refs\n", master, master->master_refs, master->ptr.refs-1);
     if (!master->master_refs && master->ptr.refs > 1)
         Vfs_TTYHangUp(master->slave->vnode->tty);
 

--- a/src/oboskrnl/vfs/socket.c
+++ b/src/oboskrnl/vfs/socket.c
@@ -565,6 +565,7 @@ obos_status NetH_AddSocketBackend(socket_ops* ops)
     if (!BACKEND_TABLE_HAS_DOMAIN(ops->domain))
     {
         OBOS_Warning("Attempted to add socket OPs for domain %d, while we do not support such a thing!\n", ops->domain);
+        OBOS_ASSERT(!"unimplemented");
         return OBOS_STATUS_INVALID_ARGUMENT;
     }
     if (Net_SocketBackendTable[ops->domain].sz < ops->proto_type.protocol)

--- a/src/oboskrnl/vfs/tmpfs.c
+++ b/src/oboskrnl/vfs/tmpfs.c
@@ -425,8 +425,6 @@ static iterate_decision populate_cb(dev_desc desc, size_t blkSize, size_t blkCou
     if (vn->vtype == VNODE_TYPE_DIR)
         vn->data = new;
     VfsH_DirentAppendChild(dent, new);
-    if (vn->vtype == VNODE_TYPE_DIR)
-        vn->tmpfs_directory_entry = new;
     vn->tmpfs_secondary_desc = desc;
     // LIST_APPEND(dirent_list, &point->dirent_list, new);
     return ITERATE_DECISION_CONTINUE;
@@ -464,7 +462,7 @@ obos_status list_dir(dev_desc dir, void* dev_vn, iterate_decision(*cb)(dev_desc 
     return OBOS_STATUS_SUCCESS;
 }
 
-static obos_status stat_fs_info(void *vn, drv_fs_info *info)
+static obos_status stat_fs_info(OBOS_MAYBE_UNUSED void *vn, drv_fs_info *info)
 {
     info->availableFiles = SIZE_MAX;
     info->fsBlockSize = 1;
@@ -684,7 +682,6 @@ obos_status Vfs_TmpFSInitializeSpecial(tmpfs** out, driver_header* backend, void
     fs->root->vnode->gid = 0;
     fs->root->vnode->uid = 0;
     fs->root->vnode->inode = fs->next_unused_inode++;
-    fs->root->vnode->tmpfs_directory_entry = fs->root;
     fs->root->vnode->mount_point = nullptr;
     fs->root->vnode->perm = (file_perm){.mode=0777};
 
@@ -697,10 +694,7 @@ obos_status Vfs_TmpFSMakeVnode(tmpfs* fs, vnode* vn, dirent* ent)
         return OBOS_STATUS_INVALID_ARGUMENT;
 
     if (vn->vtype == VNODE_TYPE_DIR)
-    {
         vn->data = ent;
-        vn->tmpfs_directory_entry = ent;
-    }
     vn->inode = fs->next_unused_inode++;
 
     return OBOS_STATUS_SUCCESS;

--- a/src/oboskrnl/vfs/tmpfs.c
+++ b/src/oboskrnl/vfs/tmpfs.c
@@ -373,7 +373,8 @@ static obos_status get_file_type(dev_desc desc, file_type *type)
 static iterate_decision populate_cb(dev_desc desc, size_t blkSize, size_t blkCount, void* userdata, const char* name)
 {   
     OBOS_UNUSED(blkSize && blkCount);
-    dirent* const dent = userdata;
+    uintptr_t* fuserdata = userdata;
+    dirent* const dent = (void*)fuserdata[0];
     for (dirent* child = dent->d_children.head; child; )
     {
         if (OBOS_CompareStringC(&child->name, name))
@@ -382,8 +383,8 @@ static iterate_decision populate_cb(dev_desc desc, size_t blkSize, size_t blkCou
         child = child->d_next_child;
     }
 
-    mount* point = Vfs_GetVnodeMount(dent->vnode);
-    tmpfs* fs = point->device->data;
+    tmpfs* fs = (tmpfs*)fuserdata[1];
+    mount* point = (mount*)fuserdata[2];
     
     vnode* vn = Vfs_Calloc(1, sizeof(*vn));
 
@@ -393,9 +394,11 @@ static iterate_decision populate_cb(dev_desc desc, size_t blkSize, size_t blkCou
     if (fs->backend->ftable.get_file_owner)
         fs->backend->ftable.get_file_owner(desc, &vn->uid, &vn->gid);
     
-    file_type type = 0;
-    fs->backend->ftable.get_file_perms(desc, &vn->perm);
-    fs->backend->ftable.get_file_type(desc, &type);
+    file_type type = -1;
+    if (fs->backend->ftable.get_file_perms)
+        fs->backend->ftable.get_file_perms(desc, &vn->perm);
+    if (fs->backend->ftable.get_file_type)
+        fs->backend->ftable.get_file_type(desc, &type);
     switch (type)
     {
         case FILE_TYPE_REGULAR_FILE:
@@ -409,7 +412,7 @@ static iterate_decision populate_cb(dev_desc desc, size_t blkSize, size_t blkCou
             fs->backend->ftable.get_linked_path(desc, &vn->un.linked);
             break;
         default:
-            OBOS_ASSERT(type);
+            OBOS_ENSURE(!"invalid type");
     }
     vn->mount_point = point;
     vn->desc = (dev_desc)vn;
@@ -442,8 +445,13 @@ obos_status list_dir(dev_desc dir, void* dev_vn, iterate_decision(*cb)(dev_desc 
         return OBOS_STATUS_NOT_FOUND;
 
     OBOS_ENSURE(vn->data);
-    if (fs->backend)
-        fs->backend->ftable.list_dir(vn->tmpfs_secondary_desc, fs->backend_fs, populate_cb, vn->data);
+    uintptr_t fuserdata[3] = {
+        (uintptr_t)vn->data,
+        (uintptr_t)fs,
+        (uintptr_t)vn->mount_point
+    };
+    if (fs->backend && vn->tmpfs_secondary_desc)
+        fs->backend->ftable.list_dir(vn->tmpfs_secondary_desc, fs->backend_fs, populate_cb, fuserdata);
 
     for (dirent* ent = ((dirent*)(vn->data))->d_children.head; ent; ent = ent->d_next_child)
     {

--- a/src/oboskrnl/vfs/tmpfs.c
+++ b/src/oboskrnl/vfs/tmpfs.c
@@ -607,7 +607,6 @@ driver_id OBOS_TmpFSDriver = {
 obos_status Vfs_TmpFSCreate(vnode** tmpfso, driver_header* backend, void* backend_fs)
 {
     vnode* tmpfsv = Vfs_Calloc(1, sizeof(*tmpfsv));
-
     tmpfs* fs = nullptr;
     obos_status status = OBOS_STATUS_SUCCESS;
 
@@ -628,6 +627,9 @@ obos_status Vfs_TmpFSCreate(vnode** tmpfso, driver_header* backend, void* backen
 
 obos_status Vfs_TmpFSInitializeSpecial(tmpfs** out, driver_header* backend, void* backend_fs)
 {
+    if (!out)
+        return OBOS_STATUS_INVALID_ARGUMENT;
+    
     *out = Vfs_Calloc(1, sizeof(tmpfs));
     tmpfs* fs = *out;
     fs->next_unused_inode = 2;
@@ -649,6 +651,21 @@ obos_status Vfs_TmpFSInitializeSpecial(tmpfs** out, driver_header* backend, void
     fs->root->vnode->tmpfs_directory_entry = fs->root;
     fs->root->vnode->mount_point = nullptr;
     fs->root->vnode->perm = (file_perm){.mode=0777};
+
+    return OBOS_STATUS_SUCCESS;
+}
+
+obos_status Vfs_TmpFSMakeVnode(tmpfs* fs, vnode* vn, dirent* ent)
+{
+    if (!fs || !vn || !ent)
+        return OBOS_STATUS_INVALID_ARGUMENT;
+
+    if (vn->vtype == VNODE_TYPE_DIR)
+    {
+        vn->data = ent;
+        vn->tmpfs_directory_entry = ent;
+    }
+    vn->inode = fs->next_unused_inode++;
 
     return OBOS_STATUS_SUCCESS;
 }

--- a/src/oboskrnl/vfs/tmpfs.c
+++ b/src/oboskrnl/vfs/tmpfs.c
@@ -1,0 +1,654 @@
+/*
+ * oboskrnl/vfs/tmpfs.c
+ *
+ * Copyright (c) 2026 Omar Berrow
+*/
+
+#include <int.h>
+#include <error.h>
+#include <memmanip.h>
+#include <klog.h>
+
+#include <vfs/alloc.h>
+#include <vfs/dirent.h>
+#include <vfs/irp.h>
+#include <vfs/mount.h>
+#include <vfs/tmpfs.h>
+#include <vfs/vnode.h>
+#include <vfs/create.h>
+
+#include <driver_interface/header.h>
+
+#define TMPFS_GET_FILE_FS(vn) ((tmpfs*)(vn->mount_point->device->data))
+
+static obos_status get_blk_size(dev_desc desc, size_t* blkSize) { OBOS_UNUSED(desc); *blkSize = 1; return OBOS_STATUS_SUCCESS; }
+static obos_status get_max_blk_count(dev_desc desc, size_t* count) { if (desc != UINTPTR_MAX) *count = ((vnode*)desc)->filesize; else return OBOS_STATUS_NOT_A_FILE; return OBOS_STATUS_SUCCESS; }
+
+static obos_status read_sync(dev_desc desc, void* buf, size_t blkCount, size_t blkOffset, size_t* nBlkRead)
+{
+    vnode* vn = (void*)desc;
+    tmpfs* fs = TMPFS_GET_FILE_FS(vn);
+    if (!fs->backend || !vn->tmpfs_secondary_desc)
+    {
+        memzero(buf, blkCount);
+        if (nBlkRead) *nBlkRead = blkCount;
+        return OBOS_STATUS_SUCCESS;
+    }
+    return fs->backend->ftable.read_sync(vn->tmpfs_secondary_desc, buf, blkCount, blkOffset, nBlkRead);
+}
+static obos_status write_sync(dev_desc desc, const void* buf, size_t blkCount, size_t blkOffset, size_t* nBlkWritten)
+{
+    OBOS_UNUSED(desc && buf && blkCount && blkOffset && nBlkWritten);
+    return OBOS_STATUS_SUCCESS;
+}
+
+static obos_status ioctl(dev_desc what, uint32_t request, void* argp)
+{
+    OBOS_UNUSED(what);
+    OBOS_UNUSED(request);
+    OBOS_UNUSED(argp);
+    return OBOS_STATUS_INVALID_IOCTL;
+}
+
+static void driver_cleanup_callback()
+{}
+
+static obos_status symlink_set_path(dev_desc desc, const char* to) { OBOS_UNUSED(desc && to); return OBOS_STATUS_SUCCESS; }
+
+static obos_status path_searchd(dirent** found, void* vn, const char* what, dev_desc parent, bool return_placeholders)
+{
+    if (!what || !vn || !found)
+        return OBOS_STATUS_INVALID_ARGUMENT;
+
+    while (*what == '/')
+        what++;
+
+    tmpfs* fs = ((vnode*)vn)->data;
+
+    if (parent == UINTPTR_MAX)
+        parent = (dev_desc)fs->root->vnode;
+
+    dirent* p = ((vnode*)parent)->data;
+    
+    dirent* ent = VfsH_DirentLookupFromCacheOnly(what, p);
+    if (ent)
+    {
+        if (ent->flags & DIRENT_TMPFS_FILE_MOVED && !return_placeholders)
+            return OBOS_STATUS_NOT_FOUND;
+        if (~ent->flags & DIRENT_TMPFS_FILE_MOVED && ent->vnode->vtype == VNODE_TYPE_DIR)
+            ent->vnode->data = ent;
+        *found = ent;
+        return OBOS_STATUS_SUCCESS;
+    }
+
+    if (!fs->backend)
+        return OBOS_STATUS_NOT_FOUND;
+
+    dev_desc sdesc = -1;
+    if (((vnode*)parent)->tmpfs_secondary_desc)
+    {
+        obos_status status = fs->backend->ftable.path_search(&sdesc, fs->backend_fs, what, ((vnode*)parent)->tmpfs_secondary_desc);
+        if (obos_is_error(status))
+            return status;
+    }
+    else
+        return OBOS_STATUS_NOT_FOUND;
+
+    char* path = nullptr;
+    size_t path_len = strlen(what);
+    path = memcpy(Vfs_Malloc(path_len+1), what, path_len+1);
+
+    dirent* last = ((vnode*)parent)->data;
+    char* iter = path;
+    while (iter < (path+path_len))
+    {
+        size_t tok_len = strchr(iter, '/');
+        if (iter[tok_len] != '\0') tok_len--;
+        if (!tok_len)
+            goto cont;
+
+        for (dirent* child = last->d_children.head; child; )
+        {
+            if (OBOS_CompareStringNC(&child->name, iter, tok_len))
+            {
+                last = child;
+                goto cont;
+            }
+
+            child = child->d_next_child;
+        }
+
+        dev_desc current_desc = 0;
+        const char ch = iter[tok_len];
+        iter[tok_len] = 0;
+        
+        obos_status status = last->vnode->tmpfs_secondary_desc ? fs->backend->ftable.path_search(&current_desc, fs->backend_fs, iter, last->vnode->tmpfs_secondary_desc) : OBOS_STATUS_SUCCESS;
+        OBOS_ENSURE(obos_is_success(status));
+        
+        iter[tok_len] = ch;
+
+        dirent* ent = Vfs_Calloc(1, sizeof(dirent));
+        OBOS_InitStringLen(&ent->name, iter, tok_len);
+
+        vnode* new = Vfs_Calloc(1, sizeof(vnode));
+        new->blkSize = 1;
+        
+        file_type type = 0;
+        fs->backend->ftable.get_file_perms(current_desc, &new->perm);
+        fs->backend->ftable.get_file_type(current_desc, &type);
+        switch (type)
+        {
+            case FILE_TYPE_REGULAR_FILE:
+                new->vtype = VNODE_TYPE_REG;
+                fs->backend->ftable.get_max_blk_count(current_desc, &new->filesize);
+                break;
+            case FILE_TYPE_DIRECTORY:
+                new->vtype = VNODE_TYPE_DIR;
+                break;
+            case FILE_TYPE_SYMBOLIC_LINK:
+                new->vtype = VNODE_TYPE_LNK;
+                break;
+            default:
+                OBOS_ASSERT(type);
+        }
+        new->mount_point = fs->root->vnode->mount_point;
+        new->desc = (dev_desc)new;
+        new->inode = fs->next_unused_inode++;
+        new->tmpfs_secondary_desc = current_desc;
+        new->mount_point = fs->root->vnode->mount_point;
+        if (current_desc)
+            fs->backend->ftable.get_linked_path(current_desc, &new->un.linked);
+
+        if (new->vtype == VNODE_TYPE_DIR)
+            new->data = ent;
+
+        ent->vnode = new;
+
+        if (ent->vnode->vtype == VNODE_TYPE_DIR)
+            ent->vnode->data = ent;
+
+        VfsH_DirentAppendChild(last, ent);
+        last = ent;
+
+        cont:
+        iter = iter + tok_len + 1;
+    }
+
+    *found = last;
+
+    return last ? OBOS_STATUS_SUCCESS : OBOS_STATUS_NOT_FOUND;
+}
+
+static obos_status path_search(dev_desc* found, void* vn, const char* what, dev_desc parent)
+{
+    dirent* last = nullptr;
+
+    obos_status status = path_searchd(&last, vn, what, parent, false);
+    if (obos_is_error(status))
+        return status;
+
+    *found = (dev_desc)last->vnode;
+    
+    return OBOS_STATUS_SUCCESS;
+}
+
+static obos_status get_linked_path(dev_desc desc, const char** found)
+{
+    vnode* vn = (void*)desc;
+    tmpfs* fs = TMPFS_GET_FILE_FS(vn);
+
+    if (vn->vtype != VNODE_TYPE_LNK)
+        return OBOS_STATUS_INVALID_ARGUMENT;
+
+    if (!fs->backend || vn->un.linked)
+        *found = vn->un.linked;
+    else if (fs->backend->ftable.get_linked_path)
+        return vn->tmpfs_secondary_desc ? fs->backend->ftable.get_linked_path(vn->tmpfs_secondary_desc, found) : OBOS_STATUS_INVALID_ARGUMENT;
+    else
+        return OBOS_STATUS_INTERNAL_ERROR;
+
+    return OBOS_STATUS_SUCCESS;
+}
+
+static obos_status move_desc_to(void* vn, const char* path, const char* newpath, const char* name)
+{
+    dirent* ent = nullptr;
+    dirent* parent = nullptr;
+    dirent* old_parent = nullptr;
+    dirent* replacement_dirent = nullptr;
+    dirent* placeholder = nullptr;
+    obos_status status = OBOS_STATUS_SUCCESS;
+
+    if (!path)
+        return OBOS_STATUS_INVALID_ARGUMENT;
+
+    status = path_searchd(&ent, vn, path, UINTPTR_MAX, false);
+    if (obos_is_error(status))
+        return status;
+    old_parent = ent->d_parent;
+
+    status = newpath ? path_searchd(&parent, vn, newpath, UINTPTR_MAX, false) : OBOS_STATUS_SUCCESS;
+    if (obos_is_error(status))
+        return status;
+
+    // If newpath/name exists, and is a placeholder (i.e., DIRENT_TMPFS_FILE_MOVED is set), remove the placeholder.
+    placeholder = VfsH_DirentLookupFromCacheOnly(name, parent ? parent : ent->d_parent);
+    if (placeholder)
+    {
+        if (~placeholder->flags & DIRENT_TMPFS_FILE_MOVED)
+            return OBOS_STATUS_ALREADY_INITIALIZED;
+        
+        VfsH_DirentRemoveChild(placeholder->d_parent, placeholder);
+        OBOS_FreeString(&placeholder->name);
+        Vfs_Free(placeholder);
+    }
+    
+    replacement_dirent = Vfs_Calloc(1, sizeof(dirent));
+    replacement_dirent->flags = DIRENT_TMPFS_FILE_MOVED;
+    replacement_dirent->vnode = nullptr;
+    OBOS_InitStringLen(&replacement_dirent->name, OBOS_GetStringCPtr(&ent->name), OBOS_GetStringSize(&ent->name));
+    
+    status = Vfs_RenameNode(ent, parent, name, true);
+    if (obos_is_error(status))
+    {
+        OBOS_FreeString(&replacement_dirent->name);
+        Vfs_Free(replacement_dirent);
+        return status;
+    }
+    
+    if (parent == old_parent && OBOS_CompareStringC(&replacement_dirent->name, name))
+    {
+        OBOS_FreeString(&replacement_dirent->name);
+        Vfs_Free(replacement_dirent);
+    }
+    else
+        VfsH_DirentAppendChild(old_parent, replacement_dirent);
+
+    return OBOS_STATUS_SUCCESS;
+}
+
+static obos_status mk_file(dev_desc* newDesc, const char* parent_path, void* vn, const char* name, file_type type, driver_file_perm perm)
+{
+    tmpfs* fs = ((vnode*)vn)->data;
+    dirent* real_parent = nullptr;
+    dirent* ent = nullptr;
+    obos_status status = OBOS_STATUS_SUCCESS;
+    uint32_t vtype = (type == FILE_TYPE_REGULAR_FILE) ? VNODE_TYPE_REG : ((type == FILE_TYPE_DIRECTORY) ? VNODE_TYPE_DIR : VNODE_TYPE_LNK);
+
+    if (obos_is_error(status = path_searchd(&real_parent, vn, parent_path, UINTPTR_MAX, false)))
+        return status;
+
+    if (obos_is_success(path_searchd(&ent, vn, name, (dev_desc)real_parent->vnode, true)))
+    {
+        if (~ent->flags & DIRENT_TMPFS_FILE_MOVED)
+            return OBOS_STATUS_ALREADY_INITIALIZED;
+
+        VfsH_DirentRemoveChild(ent->d_parent, ent);
+        OBOS_FreeString(&ent->name);
+        Vfs_Free(ent);
+    }
+
+    if (real_parent->vnode->vtype != VNODE_TYPE_DIR)
+        return OBOS_STATUS_INVALID_ARGUMENT;
+
+    status = Vfs_CreateNode(real_parent, name, vtype | BIT(31), perm);
+    if (obos_is_error(status))
+        return status;
+
+    ent = VfsH_DirentLookupFromCacheOnly(name, real_parent);
+    OBOS_ENSURE(ent);
+    *newDesc = (dev_desc)ent->vnode;
+    ent->vnode->mount_point = fs->root->vnode->mount_point;
+    ent->vnode->desc = (dev_desc)ent->vnode;
+    if (vtype == VNODE_TYPE_DIR)
+        ent->vnode->data = ent;
+
+    return OBOS_STATUS_SUCCESS;
+}
+
+static obos_status remove_file(void* vn, const char* path)
+{
+    dirent* ent = nullptr;
+    dirent* replacement_dirent = nullptr;
+    dirent* old_parent = nullptr;
+    obos_status status = OBOS_STATUS_SUCCESS;
+
+    status = path_searchd(&ent, vn, path, UINTPTR_MAX, false);
+    if (obos_is_error(status))
+        return status;
+    old_parent = ent->d_parent;
+
+    replacement_dirent = Vfs_Calloc(1, sizeof(dirent));
+    replacement_dirent->flags = DIRENT_TMPFS_FILE_MOVED;
+    replacement_dirent->vnode = nullptr;
+    OBOS_InitStringLen(&replacement_dirent->name, OBOS_GetStringCPtr(&ent->name), OBOS_GetStringSize(&ent->name));
+
+    status = Vfs_UnlinkNode(ent, true);
+
+    if (obos_is_error(status))
+    {
+        OBOS_FreeString(&replacement_dirent->name);
+        Vfs_Free(replacement_dirent);
+    }
+    else
+        VfsH_DirentAppendChild(old_parent, replacement_dirent);
+
+    return status;
+}
+
+static obos_status set_file_perms(dev_desc desc, driver_file_perm newperm)
+{
+    OBOS_UNUSED(desc);
+    OBOS_UNUSED(newperm);
+    return OBOS_STATUS_SUCCESS;
+}
+
+static obos_status get_file_perms(dev_desc desc, driver_file_perm *perm)
+{
+    vnode* vn = (vnode*)desc;
+    *perm = vn->perm;
+    return OBOS_STATUS_SUCCESS;
+}
+
+static obos_status set_file_owner(dev_desc desc, uid owner_uid, gid group_uid)
+{
+    OBOS_UNUSED(desc && owner_uid && group_uid);
+    return OBOS_STATUS_SUCCESS;
+}
+
+static obos_status get_file_type(dev_desc desc, file_type *type)
+{
+    vnode* vn = (vnode*)desc;
+    switch (vn->vtype) {
+        case VNODE_TYPE_REG: *type = FILE_TYPE_REGULAR_FILE; break;
+        case VNODE_TYPE_DIR: *type = FILE_TYPE_DIRECTORY; break;
+        case VNODE_TYPE_LNK: *type = FILE_TYPE_SYMBOLIC_LINK; break;
+        default: return OBOS_STATUS_INVALID_ARGUMENT;
+    }
+    return OBOS_STATUS_SUCCESS;
+}
+
+static iterate_decision populate_cb(dev_desc desc, size_t blkSize, size_t blkCount, void* userdata, const char* name)
+{   
+    OBOS_UNUSED(blkSize && blkCount);
+    dirent* const dent = userdata;
+    for (dirent* child = dent->d_children.head; child; )
+    {
+        if (OBOS_CompareStringC(&child->name, name))
+            return ITERATE_DECISION_CONTINUE;
+
+        child = child->d_next_child;
+    }
+
+    mount* point = Vfs_GetVnodeMount(dent->vnode);
+    tmpfs* fs = point->device->data;
+    
+    vnode* vn = Vfs_Calloc(1, sizeof(*vn));
+
+    vn->filesize = blkCount;
+    vn->blkSize = 1;
+    vn->inode = fs->next_unused_inode++;
+    if (fs->backend->ftable.get_file_owner)
+        fs->backend->ftable.get_file_owner(desc, &vn->uid, &vn->gid);
+    
+    file_type type = 0;
+    fs->backend->ftable.get_file_perms(desc, &vn->perm);
+    fs->backend->ftable.get_file_type(desc, &type);
+    switch (type)
+    {
+        case FILE_TYPE_REGULAR_FILE:
+            vn->vtype = VNODE_TYPE_REG;
+            break;
+        case FILE_TYPE_DIRECTORY:
+            vn->vtype = VNODE_TYPE_DIR;
+            break;
+        case FILE_TYPE_SYMBOLIC_LINK:
+            vn->vtype = VNODE_TYPE_LNK;
+            fs->backend->ftable.get_linked_path(desc, &vn->un.linked);
+            break;
+        default:
+            OBOS_ASSERT(type);
+    }
+    vn->mount_point = point;
+    vn->desc = (dev_desc)vn;
+    vn->inode = fs->next_unused_inode++;
+    
+    dirent* new = Vfs_Calloc(1, sizeof(dirent));
+    OBOS_StringSetAllocator(&new->name, Vfs_Allocator);
+    OBOS_InitString(&new->name, name);
+    new->vnode = vn;
+    if (vn->vtype == VNODE_TYPE_DIR)
+        vn->data = new;
+    VfsH_DirentAppendChild(dent, new);
+    if (vn->vtype == VNODE_TYPE_DIR)
+        vn->tmpfs_directory_entry = new;
+    vn->tmpfs_secondary_desc = desc;
+    // LIST_APPEND(dirent_list, &point->dirent_list, new);
+    return ITERATE_DECISION_CONTINUE;
+}
+
+obos_status list_dir(dev_desc dir, void* dev_vn, iterate_decision(*cb)(dev_desc desc, size_t blkSize, size_t blkCount, void* userdata, const char* name), void* userdata)
+{
+    OBOS_UNUSED(dev_vn);
+
+    tmpfs* fs = ((vnode*)dev_vn)->data;
+    vnode* vn = (vnode*)(dir == UINTPTR_MAX ? (dev_desc)fs->root->vnode : dir);
+
+    if (vn->vtype != VNODE_TYPE_DIR)
+        return OBOS_STATUS_INVALID_ARGUMENT;
+
+    OBOS_ENSURE(vn->data);
+    if (fs->backend)
+        fs->backend->ftable.list_dir(vn->tmpfs_secondary_desc, fs->backend_fs, populate_cb, vn->data);
+
+    for (dirent* ent = ((dirent*)(vn->data))->d_children.head; ent; ent = ent->d_next_child)
+    {
+        if (ent->flags & DIRENT_TMPFS_FILE_MOVED)
+            continue;
+        if (cb((dev_desc)ent->vnode, 1, ent->vnode->filesize, userdata, OBOS_GetStringCPtr(&ent->name)) == ITERATE_DECISION_STOP)
+            break;
+    }
+    
+    return OBOS_STATUS_SUCCESS;
+}
+
+static obos_status stat_fs_info(void *vn, drv_fs_info *info)
+{
+    info->availableFiles = SIZE_MAX;
+    info->fsBlockSize = 1;
+    info->partBlockSize = 1;
+    info->freeBlocks = SIZE_MAX;
+    info->fileCount = 0;
+    info->nameMax = 255;
+    info->szFs = SIZE_MAX;
+    return OBOS_STATUS_SUCCESS;
+}
+
+static dev_desc irp_process_dryop(irp* req)
+{
+    dev_desc desc = req->desc;
+    size_t blkCount = req->blkCount;
+    size_t blkOffset = req->blkOffset;
+    vnode* vno = (void*)desc;
+    if (!vno)
+        return OBOS_STATUS_INVALID_ARGUMENT;
+    if (!blkCount)
+        return OBOS_STATUS_SUCCESS;
+    if (vno->vtype != VNODE_TYPE_REG)
+        return OBOS_STATUS_NOT_A_FILE;
+    size_t filesize = vno->filesize;
+    if (blkOffset >= filesize)
+    {
+        req->nBlkRead = 0;
+        return OBOS_STATUS_SUCCESS;
+    }
+    return OBOS_STATUS_SUCCESS;
+}
+
+static obos_status vnode_search(void** vn_found, dev_desc desc, void* dev_vn)
+{
+    OBOS_UNUSED(dev_vn);
+    OBOS_ASSERT(desc != UINTPTR_MAX);
+    *vn_found = (void*)desc;
+    return OBOS_STATUS_SUCCESS;
+}
+
+static obos_status submit_irp(void* /* irp* */ request_)
+{
+    if (!request_)
+        return OBOS_STATUS_INVALID_ARGUMENT;
+    irp* request = request_;
+    if (request->dryOp)
+        request->status = irp_process_dryop(request);
+    else
+        request->status = request->op == IRP_READ ? 
+            read_sync(request->desc, request->buff, request->blkCount, request->blkOffset, &request->nBlkRead) :
+            write_sync(request->desc, request->cbuff, request->blkCount, request->blkOffset, &request->nBlkRead);
+    request->evnt = nullptr;
+    return OBOS_STATUS_SUCCESS;
+}
+
+static obos_status get_file_inode(dev_desc desc, uint32_t *out)
+{
+    vnode* vn = (void*)desc;
+    if (vn->inode)
+        *out = vn->inode;
+    else
+        *out = ++TMPFS_GET_FILE_FS(vn)->next_unused_inode;
+    return OBOS_STATUS_SUCCESS;
+}
+
+static obos_status trunc_file(dev_desc desc, size_t newsize /* note, newsize must be less than the filesize */)
+{
+    OBOS_UNUSED(desc && newsize);
+    return OBOS_STATUS_SUCCESS;
+}
+
+static obos_status mount_p(void* vnp, void* targetp)
+{
+    vnode* vn = vnp;
+    dirent* target = targetp;
+
+    tmpfs* fs = vn->data;
+
+    fs->root->vnode->mount_point = target->vnode->mount_point;
+    
+    return OBOS_STATUS_SUCCESS;
+}
+
+static obos_status hardlink_file(dev_desc desc, const char* parent_path, void* vn, const char* name)
+{
+    dirent* real_parent = nullptr;
+    dirent* ent = nullptr;
+    obos_status status = OBOS_STATUS_SUCCESS;
+
+    if (obos_is_error(status = path_searchd(&real_parent, vn, parent_path, UINTPTR_MAX, false)))
+        return status;
+
+    if (obos_is_success(path_searchd(&ent, vn, name, (dev_desc)real_parent->vnode, true)))
+    {
+        if (~ent->flags & DIRENT_TMPFS_FILE_MOVED)
+            return OBOS_STATUS_ALREADY_INITIALIZED;
+
+        VfsH_DirentRemoveChild(ent->d_parent, ent);
+        OBOS_FreeString(&ent->name);
+        Vfs_Free(ent);
+    }
+
+    ent = Vfs_Calloc(1, sizeof(dirent));
+    ent->vnode = (vnode*)desc;
+    OBOS_InitString(&ent->name, name);
+    VfsH_DirentAppendChild(real_parent, ent);
+
+    return OBOS_STATUS_SUCCESS;
+}
+
+driver_id OBOS_TmpFSDriver = {
+    .id=0,
+    .header = {
+        .magic = OBOS_DRIVER_MAGIC,
+        .flags = DRIVER_HEADER_HAS_STANDARD_INTERFACES|DRIVER_HEADER_DIRENT_CB_PATHS,
+        .ftable = {
+            .driver_cleanup_callback = driver_cleanup_callback,
+            .ioctl = ioctl,
+            .get_blk_size = get_blk_size,
+            .get_max_blk_count = get_max_blk_count,
+            .query_user_readable_name = nullptr,
+            .foreach_device = nullptr,
+            .read_sync = read_sync,
+            .write_sync = write_sync,
+            .submit_irp = submit_irp,
+            .finalize_irp = nullptr,
+
+            .query_path = nullptr,
+            .path_search = path_search,
+            .get_linked_path = get_linked_path,
+            .vnode_search = vnode_search,
+            .pmove_desc_to = move_desc_to,
+            .pmk_file = mk_file,
+            .premove_file = remove_file,
+            .get_file_perms = get_file_perms,
+            .set_file_perms = set_file_perms,
+            .set_file_owner = set_file_owner,
+            .get_file_type = get_file_type,
+            .get_file_inode = get_file_inode,
+            .list_dir = list_dir,
+            .stat_fs_info = stat_fs_info,
+            .symlink_set_path = symlink_set_path,
+            .trunc_file = trunc_file,
+            .mount = mount_p,
+            .phardlink_file = hardlink_file,
+        },
+        .driverName = "TmpFS Driver",
+        .version = 1,
+    }
+};
+
+obos_status Vfs_TmpFSCreate(vnode** tmpfso, driver_header* backend, void* backend_fs)
+{
+    vnode* tmpfsv = Vfs_Calloc(1, sizeof(*tmpfsv));
+
+    tmpfs* fs = nullptr;
+    obos_status status = OBOS_STATUS_SUCCESS;
+
+    status = Vfs_TmpFSInitializeSpecial(&fs, backend, backend_fs);
+    if (obos_is_error(status))
+        return status;
+
+    tmpfsv->data = fs;
+    tmpfsv->blkSize = 1;
+    tmpfsv->filesize = -1;
+    tmpfsv->vtype = VNODE_TYPE_BLK;
+    fs->obj = tmpfsv;
+
+    *tmpfso = tmpfsv;
+    
+    return OBOS_STATUS_SUCCESS;
+}
+
+obos_status Vfs_TmpFSInitializeSpecial(tmpfs** out, driver_header* backend, void* backend_fs)
+{
+    *out = Vfs_Calloc(1, sizeof(tmpfs));
+    tmpfs* fs = *out;
+    fs->next_unused_inode = 2;
+    fs->backend = backend;
+    fs->backend_fs = backend_fs;
+    
+    fs->root = Vfs_Calloc(1, sizeof(*fs->root));
+    OBOS_InitStringLen(&fs->root->name, "/", 1);
+    fs->root->vnode = Vfs_Calloc(1, sizeof(vnode));
+    fs->root->vnode->blkSize = 1;
+    fs->root->vnode->filesize = 0;
+    fs->root->vnode->vtype = VNODE_TYPE_DIR;
+    fs->root->vnode->desc = (dev_desc)fs->root->vnode;
+    fs->root->vnode->tmpfs_secondary_desc = UINTPTR_MAX;
+    fs->root->vnode->data = fs->root;
+    fs->root->vnode->gid = 0;
+    fs->root->vnode->uid = 0;
+    fs->root->vnode->inode = fs->next_unused_inode++;
+    fs->root->vnode->tmpfs_directory_entry = fs->root;
+    fs->root->vnode->mount_point = nullptr;
+    fs->root->vnode->perm = (file_perm){.mode=0777};
+
+    return OBOS_STATUS_SUCCESS;
+}

--- a/src/oboskrnl/vfs/tmpfs.c
+++ b/src/oboskrnl/vfs/tmpfs.c
@@ -8,6 +8,7 @@
 #include <error.h>
 #include <memmanip.h>
 #include <klog.h>
+#include <perm.h>
 
 #include <vfs/alloc.h>
 #include <vfs/dirent.h>
@@ -323,6 +324,7 @@ static obos_status remove_file(void* vn, const char* path)
     replacement_dirent->vnode = nullptr;
     OBOS_InitStringLen(&replacement_dirent->name, OBOS_GetStringCPtr(&ent->name), OBOS_GetStringSize(&ent->name));
 
+    ent->vnode->flags |= VFLAGS_TMPFS_FILE_DEAD;
     status = Vfs_UnlinkNode(ent, true);
 
     if (obos_is_error(status))
@@ -436,6 +438,8 @@ obos_status list_dir(dev_desc dir, void* dev_vn, iterate_decision(*cb)(dev_desc 
 
     if (vn->vtype != VNODE_TYPE_DIR)
         return OBOS_STATUS_INVALID_ARGUMENT;
+    if (vn->flags & VFLAGS_TMPFS_FILE_DEAD)
+        return OBOS_STATUS_NOT_FOUND;
 
     OBOS_ENSURE(vn->data);
     if (fs->backend)
@@ -609,6 +613,7 @@ obos_status Vfs_TmpFSCreate(vnode** tmpfso, driver_header* backend, void* backen
     vnode* tmpfsv = Vfs_Calloc(1, sizeof(*tmpfsv));
     tmpfs* fs = nullptr;
     obos_status status = OBOS_STATUS_SUCCESS;
+    capability cap = {};
 
     status = Vfs_TmpFSInitializeSpecial(&fs, backend, backend_fs);
     if (obos_is_error(status))
@@ -617,7 +622,30 @@ obos_status Vfs_TmpFSCreate(vnode** tmpfso, driver_header* backend, void* backen
     tmpfsv->data = fs;
     tmpfsv->blkSize = 1;
     tmpfsv->filesize = -1;
+    tmpfsv->flags |= VFLAGS_TMPFS;
     tmpfsv->vtype = VNODE_TYPE_BLK;
+    status = OBOS_CapabilityFetch("fs/tmpfs-perm", &cap, false);
+    if (status == OBOS_STATUS_NOT_FOUND)
+    {
+        cap.allow_user = true;
+        cap.allow_group = false;
+        cap.allow_other = false;
+        cap.owner = ROOT_UID;
+        cap.group = ROOT_GID;
+    }
+    else if (obos_is_error(status))
+    {
+        OBOS_Error("%s: OBOS_CapabilityFetch returned %d\n", __func__, status);
+        return OBOS_STATUS_INTERNAL_ERROR;
+    }
+    tmpfsv->perm.owner_read = cap.allow_user;
+    tmpfsv->perm.owner_write = cap.allow_user;
+    tmpfsv->perm.group_read = cap.allow_group;
+    tmpfsv->perm.group_write = cap.allow_group;
+    tmpfsv->perm.other_read = cap.allow_other;
+    tmpfsv->perm.other_write = cap.allow_other;
+    tmpfsv->uid = cap.owner;
+    tmpfsv->gid = cap.group;
     fs->obj = tmpfsv;
 
     *tmpfso = tmpfsv;

--- a/src/oboskrnl/vfs/tmpfs.h
+++ b/src/oboskrnl/vfs/tmpfs.h
@@ -26,5 +26,7 @@ typedef struct tmpfs {
 
 obos_status Vfs_TmpFSCreate(vnode** tmpfs, driver_header* backend, void* backend_fs);
 obos_status Vfs_TmpFSInitializeSpecial(tmpfs** out, driver_header* backend, void* backend_fs);
+// Initializes the necessary vnode fields in 'vn' for it to be used in the tmpfs 'fs'.
+obos_status Vfs_TmpFSMakeVnode(tmpfs* fs, vnode* vn, dirent* ent);
 
 extern driver_id OBOS_TmpFSDriver;

--- a/src/oboskrnl/vfs/tmpfs.h
+++ b/src/oboskrnl/vfs/tmpfs.h
@@ -1,0 +1,30 @@
+/*
+ * oboskrnl/vfs/tmpfs.h
+ *
+ * Copyright (c) 2026 Omar Berrow
+*/
+
+#pragma once
+
+#include <int.h>
+#include <error.h>
+
+#include <vfs/vnode.h>
+#include <vfs/dirent.h>
+
+#include <driver_interface/header.h>
+
+typedef struct tmpfs {
+    driver_header* backend;
+    vnode* backend_fs;
+
+    dirent* root;
+    vnode* obj;
+
+    uint32_t next_unused_inode;
+} tmpfs;
+
+obos_status Vfs_TmpFSCreate(vnode** tmpfs, driver_header* backend, void* backend_fs);
+obos_status Vfs_TmpFSInitializeSpecial(tmpfs** out, driver_header* backend, void* backend_fs);
+
+extern driver_id OBOS_TmpFSDriver;

--- a/src/oboskrnl/vfs/vnode.h
+++ b/src/oboskrnl/vfs/vnode.h
@@ -54,7 +54,8 @@ enum
     VFLAGS_PTMX = 128,
     VFLAGS_PTS_LOCKED = 256,
     // The NIC will inject packets into the network stack
-    VFLAGS_NIC_PACKET_INJECT = 512,    
+    VFLAGS_NIC_PACKET_INJECT = 512,
+    VFLAGS_TMPFS_FILE_DEAD = 1024,
 };
 
 // basically a struct specinfo, but renamed.
@@ -82,6 +83,8 @@ typedef struct vnode
         struct tty* tty;
         struct net_tables* net_tables;
     };
+    dev_desc tmpfs_secondary_desc;
+    dirent* tmpfs_directory_entry; // only exists for directories
     uint32_t vtype;
     uint32_t flags;
     struct mount* mount_point;

--- a/src/oboskrnl/vfs/vnode.h
+++ b/src/oboskrnl/vfs/vnode.h
@@ -42,20 +42,22 @@ enum
 };
 enum 
 {
-    VFLAGS_MOUNTPOINT = 1,
-    VFLAGS_IS_TTY = 2,
-    VFLAGS_PARTITION = 4,
-    VFLAGS_FB = 8,
+    VFLAGS_MOUNTPOINT = BIT(0),
+    VFLAGS_IS_TTY = BIT(1),
+    VFLAGS_PARTITION = BIT(2),
+    VFLAGS_FB = BIT(3),
     // A file that only provides events, and cannot be read/written.
-    VFLAGS_EVENT_DEV = 16,
+    VFLAGS_EVENT_DEV = BIT(4),
     // The driver implementing this vnode is DEAD and should NOT be used.
-    VFLAGS_DRIVER_DEAD = 32,
-    VFLAGS_NIC_NO_FCS = 64,
-    VFLAGS_PTMX = 128,
-    VFLAGS_PTS_LOCKED = 256,
+    VFLAGS_DRIVER_DEAD = BIT(5),
+    VFLAGS_NIC_NO_FCS = BIT(6),
+    VFLAGS_PTMX = BIT(7),
+    VFLAGS_PTS_LOCKED = BIT(8),
     // The NIC will inject packets into the network stack
-    VFLAGS_NIC_PACKET_INJECT = 512,
-    VFLAGS_TMPFS_FILE_DEAD = 1024,
+    VFLAGS_NIC_PACKET_INJECT = BIT(9),
+    VFLAGS_TMPFS_FILE_DEAD = BIT(10),
+    VFLAGS_TMPFS = BIT(11),
+    VFLAGS_REFERS_CTTY = BIT(12),
 };
 
 // basically a struct specinfo, but renamed.

--- a/src/oboskrnl/vfs/vnode.h
+++ b/src/oboskrnl/vfs/vnode.h
@@ -86,7 +86,6 @@ typedef struct vnode
         struct net_tables* net_tables;
     };
     dev_desc tmpfs_secondary_desc;
-    dirent* tmpfs_directory_entry; // only exists for directories
     uint32_t vtype;
     uint32_t flags;
     struct mount* mount_point;
@@ -104,7 +103,6 @@ typedef struct vnode
     gid gid; // the group's GID.
     dev_desc desc; // the cached device descriptor.
     fd_list opened;
-    size_t nMappedRegions;
     size_t nWriteableMappedRegions;
     struct partition* partitions;
     size_t nPartitions;

--- a/src/user-utilities/mount.c
+++ b/src/user-utilities/mount.c
@@ -1,8 +1,11 @@
-#include <stdint.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <stddef.h>
 #include <stdio.h>
+#include <unistd.h>
 #include <errno.h>
+#include <strings.h>
+#include <fcntl.h>
 
 #include <obos/error.h>
 #include <obos/syscall.h>
@@ -26,21 +29,130 @@ static int parse_file_status(obos_status status)
     }
 }
 
+const char* usage = "%s -h\n%s device target\n%s -t target\n%s -o overlay_path target\n%s -s devfs/initrd target\n";
+
+enum {
+    TMPFS_INITRD,
+    TMPFS_DEVFS,
+    TMPFS_NEW,
+    TMPFS_OVERLAY,
+};
+#define Sys_OpenTmpFS 149
+
+#define Sys_Mount2 150
+
 int main(int argc, char** argv)
 {
-    if (argc < 3)
+    int opt = 0;
+
+    const char* target = NULL;
+    const char* device = NULL;
+    handle overlay = HANDLE_INVALID;
+    
+    bool tg_tmpfs = false;
+    bool tg_tmpfs_system = false;
+    int tmpfs_type = TMPFS_NEW;
+
+    while ((opt = getopt(argc, argv, "+tosh")) != -1)
     {
-        printf("Usage: %s device target\n", argv[0]);
-        return -1;
+        switch (opt)
+        {
+            case 't':
+                tg_tmpfs = true;
+                tmpfs_type = TMPFS_NEW;
+                break;
+            case 'o':
+                tg_tmpfs = true;
+                tmpfs_type = TMPFS_OVERLAY;
+                break;
+            case 's':
+                tg_tmpfs = true;
+                tg_tmpfs_system = true;
+                tmpfs_type = TMPFS_DEVFS;
+                break;
+            case 'h':
+            default:
+                fprintf(stderr, usage, argv[0], argv[0], argv[0], argv[0], argv[0]);
+                return opt != 'h';
+        }
     }
-    char* target = argv[2];
-    char* device = argv[1];
-    obos_status st = syscall2(Sys_Mount, target, device);
-    if (obos_is_error(st))
+
+    if (tmpfs_type == TMPFS_NEW && tg_tmpfs)
     {
+        target = argv[optind];
+        if (!target)
+        {
+            fprintf(stderr, usage, argv[0], argv[0], argv[0], argv[0], argv[0]);
+            return 1;
+        }
+    }
+    else
+    {
+        target = argv[optind+1];
+        device = argv[optind];
+
+        if (!device || !target)
+        {
+            fprintf(stderr, usage, argv[0], argv[0], argv[0], argv[0], argv[0]);
+            return 1;
+        }
+    }
+
+    if (tg_tmpfs_system)
+    {
+        if (strcasecmp(device, "devfs") == 0)
+            tmpfs_type = TMPFS_DEVFS;
+        else if (strcasecmp(device, "initrd") == 0)
+            tmpfs_type = TMPFS_INITRD;
+        else
+        {
+            fprintf(stderr, "Expected either initrd or devfs as target to %s -s\n", argv[0]);
+            fprintf(stderr, usage, argv[0], argv[0], argv[0], argv[0], argv[0]);
+            return 1;
+        }
+    }
+    if (tmpfs_type == TMPFS_OVERLAY)
+    {
+        int fd = open(device, O_RDWR);
+        if (fd < 0)
+        {
+            perror("open");
+            return -1;
+        }
+
+        overlay = fd;
+    }
+
+    if (tg_tmpfs)
+    {
+        handle tmpfs = syscall0(Sys_FdAlloc);
+
+        obos_status st = syscall4(Sys_OpenTmpFS, tmpfs, tmpfs_type, 0, overlay);
+        if (obos_is_error(st))
+        {
+            errno = parse_file_status(st);
+            perror("Sys_OpenTmpFS");
+            return -1;
+        }
+
+        st = syscall2(Sys_Mount2, target, tmpfs);
         errno = parse_file_status(st);
-        perror("Sys_Mount");
-        return -1;
+        syscall1(Sys_HandleClose, tmpfs);
+        if (obos_is_error(st))
+        {
+            perror("Sys_Mount2");
+            return -1;
+        }
+    }
+    else
+    {
+        obos_status st = syscall2(Sys_Mount, target, device);
+        if (obos_is_error(st))
+        {
+            errno = parse_file_status(st);
+            perror("Sys_Mount");
+            return -1;
+        }
     }
 
     return 0;


### PR DESCRIPTION
Adds a new interface for tmpfs that allows it to be instanced. This will allow for a devfs interface, and it also supersedes the old intird driver's tmpfs implementation. The tmpfs implementation also allows for overlays of any file system.